### PR TITLE
feat: add secrets manager access key rotation

### DIFF
--- a/.boilerplate/boilerplate.yml
+++ b/.boilerplate/boilerplate.yml
@@ -1,50 +1,30 @@
 ##
-# (c) 2025 - Cloud Ops Works LLC - https://cloudops.works/
-#            On GitHub: https://github.com/cloudopsworks
-#            Distributed Under Apache v2.0 License
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
 #
+# Terragrunt Boilerplate Configuration
 variables:
   # Generic Boilerplate Variables Setup
-  - name: organization_name
-    order: 0
-    description: "Organization Name"
-    type: string
-    default: "Organization"
-    confirm: true
-  - name: organization_unit
-    order: 1
-    description: "Organization Unit"
-    type: string
-    default: "Unit"
-    confirm: true
-  - name: environment_name
-    order: 2
-    description: "Environment Name"
-    type: string
-    default: "DEV"
-    confirm: true
-  - name: environment_type
-    order: 3
-    description: "Environment Type"
-    type: string
-    default: "Testing"
-    confirm: true
-  - name: hub_spoke
-    order: 4
-    description: "Hub and Spoke architecture"
-    type: bool
-    default: false
-    confirm: true
   - name: is_hub
-    order: 5
+    order: 0
     description: "Is this a hub configuration?"
     type: bool
     default: false
     confirm: true
   - name: tags
-    order: 6
+    order: 1
     description: "Tags"
     type: map
     default: {}
     confirm: true
   # End - Generic Boilerplate Variables Setup
+
+hooks:
+  after:
+    - command: "git"
+      args: ["add", "."]
+      dir: "{{ outputFolder }}"

--- a/.boilerplate/inputs.yaml
+++ b/.boilerplate/inputs.yaml
@@ -1,18 +1,65 @@
 # Module configuration
-# Required variables
-{{- range .requiredVariables }}
-{{- if ne .Name "org"}}
-# Description {{ .Description }} , Type: {{ .Type }}
-{{ .Name }}: {{ .DefaultValuePlaceholder }}
-{{- end }}
 
-{{- end }}
-# Optional variables
-{{- range .optionalVariables }}
-{{- if ne .Name "is_hub" "spoke_def" "extra_args" }}
-# Description {{ .Description }} , Type: {{ .Type }}
-#{{ .Name }}: {{ .DefaultValue }}
-{{- end }}
+secrets_manager_store: false # (Optional) Store Terraform-generated console passwords and access keys in AWS Secrets Manager under /<org_unit>/<environment_name>/<environment_type>. Default: false
 
-{{- end }}
+default_pgp_key: "" # (Optional) Default PGP key for console passwords and access keys; use raw armored PGP or "_aws:<secret_id>" to load from Secrets Manager. Default: ""
 
+access_key_rotation: # (Optional) Opt-in AWS Secrets Manager rotation control plane. Default: disabled
+  enabled: false # (Optional) Configure AWS Secrets Manager rotation for selected IAM users. Default: false
+  create_lambda: true # (Optional) Create the module IAM access key rotation Lambda. Set false to use lambda_arn. Default: true
+  lambda_arn: null # (Optional) Existing rotation Lambda ARN when create_lambda is false. Default: null
+  lambda_layer_arns: [] # (Optional) Lambda layer ARNs. Required when PGP is active with the module-created Lambda; include a layer with pgpy. Default: []
+  lambda_timeout: 60 # (Optional) Module-created Lambda timeout in seconds. Default: 60
+  lambda_memory_size: 256 # (Optional) Module-created Lambda memory size in MB. Default: 256
+  lambda_function_name: "" # (Optional) Module-created Lambda function name; blank uses <system_name_short>-iam-key-rotation and is truncated to 64 characters. Default: ""
+  lambda_role_name: "" # (Optional) Module-created Lambda IAM role name; blank uses <system_name_short>-iam-key-rotation-lambda and is truncated to 64 characters. Default: ""
+  log_retention_days: 30 # (Optional) CloudWatch log retention for the module-created Lambda. Default: 30
+  automatically_after_days: 90 # (Optional) Secrets Manager rotation interval when schedule_expression is not set. Default: rotate_after_days
+  schedule_expression: null # (Optional) Secrets Manager schedule expression such as "rate(30 days)"; do not set with automatically_after_days. Default: null
+  schedule_duration: null # (Optional) Rotation window duration such as "2h" when schedule_expression is set. Default: null
+  rotate_immediately: false # (Optional) Rotate immediately when AWS Secrets Manager rotation is configured. Default: false
+  rotate_after_days: 90 # (Optional) Lambda-side minimum age before creating a replacement key. Default: 90
+  grace_period_days: 7 # (Optional) Days before older non-current keys are deactivated during a rotation invocation. Default: 7
+  inactive_key_retention_days: 30 # (Optional) Additional days before deleting inactive keys when delete_inactive_keys is true. Default: 30
+  delete_inactive_keys: false # (Optional) Delete inactive keys after grace_period_days + inactive_key_retention_days. Default: false
+  users: [] # (Optional) Explicit module-managed user allowlist; when non-empty it overrides group-derived selection. Default: []
+  groups: [] # (Optional) Group references from users[*].groups used to derive selected users when users is empty. Default: []
+  exclude_users: [] # (Optional) Module-managed users removed from all-users, explicit, or group-derived scope. Default: []
+  create_secrets: true # (Optional) Create one Secrets Manager secret per selected user and configure rotation on it. Default: true
+  secret_prefix: "" # (Optional) Prefix for module-created Secrets Manager secrets; blank uses /<org_unit>/<environment_name>/<environment_type>/iam-user/access-key-rotation. Default: ""
+  secret_arns: {} # (Optional) Map of user name to existing Secrets Manager secret ARN/name when create_secrets is false or custom destinations are required. Default: {}
+  secret_kms_key_id: null # (Optional) KMS key ID/ARN for module-created rotation secrets and config. Default: null
+  secret_recovery_window_in_days: 30 # (Optional) Recovery window in days for module-created Secrets Manager secrets. Default: 30
+  config_secret_name: "" # (Optional) Name for the module-created Lambda configuration secret; blank uses <secret_prefix>/_rotation-config. Default: ""
+
+users: [] # (Optional) IAM users managed by this module. Default: []
+# users:
+#   - name: "username" # (Required) IAM user name.
+#     path: "/" # (Optional) IAM user path. Default: "/"
+#     pgp_key: "" # (Optional) User-specific PGP key; use raw armored PGP or "_aws:<secret_id>". Default: ""
+#     access_key_rotation_enabled: true # (Optional) Set false to opt this user out of module-level access_key_rotation selection. Default: true
+#     groups: ["developers"] # (Optional) Group memberships; use group.name for named groups or group.name_prefix for prefixed groups. Default: []
+#     access_keys: [] # (Optional) Terraform-managed access keys. Skipped automatically while this user is managed by access_key_rotation to avoid aws_iam_access_key recreation. Default: []
+#     console_access: null # (Optional) Console login profile configuration. Default: null
+#     code_commit: null # (Optional) CodeCommit HTTP/SSH credential configuration. Default: null
+
+groups: [] # (Optional) IAM groups managed or referenced by this module. Default: []
+# groups:
+#   - name: "developers" # (Optional) Explicit group name. Either name or name_prefix is required.
+#     name_prefix: "" # (Optional) Prefix for generated group name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+#     path: "/" # (Optional) IAM group path. Default: "/"
+#     existing: false # (Optional) Reference an existing IAM group by name instead of creating it. Default: false
+#     policy_attachments: [] # (Optional) Existing managed policy ARNs to attach. Default: []
+#     policy_refs: [] # (Optional) Names or prefixes of policies created by this module to attach. Default: []
+#     inline_policies: [] # (Optional) Inline policies to create on the group. Default: []
+
+policies: [] # (Optional) IAM managed policies created by this module. Default: []
+# policies:
+#   - name: "S3ReadOnly" # (Optional) Explicit policy name. Either name or name_prefix is required.
+#     name_prefix: "" # (Optional) Prefix for generated policy name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+#     statements: # (Required) IAM policy statements.
+#       - sid: "ListBuckets" # (Optional) Statement ID.
+#         effect: "Allow" # (Required) Statement effect. Valid values: "Allow", "Deny".
+#         actions: ["s3:ListAllMyBuckets"] # (Required) IAM actions.
+#         resources: ["*"] # (Required) IAM resources.
+#         conditions: [] # (Optional) IAM conditions with test, variable, and values. Default: []

--- a/.boilerplate/terragrunt.hcl
+++ b/.boilerplate/terragrunt.hcl
@@ -1,5 +1,4 @@
 locals {
-  {{- if .hub_spoke }}
   local_vars  = yamldecode(file("./inputs.yaml"))
   spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
   region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
@@ -19,21 +18,10 @@ locals {
     local.spoke_tags,
     local.local_tags
   )
-  {{- else }}
-  local_vars  = yamldecode(file("./inputs.yaml"))
-  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
-  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
-  local_tags  = jsondecode(file("./local-tags.json"))
-
-  tags = merge(
-    local.global_tags,
-    local.local_tags
-  )
-  {{- end }}
 }
 
 include "root" {
-  path = find_in_parent_folders("root.hcl")
+  path = find_in_parent_folders("{{ .RootFileName }}")
 }
 
 terraform {
@@ -41,27 +29,16 @@ terraform {
 }
 
 inputs = {
-  # org = {
-  #   organization_name = local.env_vars.org.organization_name
-  #   organization_unit = local.env_vars.org.organization_unit
-  #   environment_name  = local.env_vars.org.environment_name
-  #   environment_type  = local.env_vars.org.environment_type
-  # }
-  org = local.env_vars.org
-  {{- if .hub_spoke }}
-  is_hub = {{ .is_hub }}
-  spoke_def = local.spoke_vars.spoke_def
-  {{- end}}
-  ## Required
+  is_hub     = {{ .is_hub }}
+  org        = local.env_vars.org
+  spoke_def  = local.spoke_vars.spoke
   {{- range .requiredVariables }}
   {{- if ne .Name "org" }}
-  {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
+  {{ .Name }} = local.local_vars.{{ .Name }}
   {{- end }}
   {{- end }}
-
-  ## Optional
   {{- range .optionalVariables }}
-  {{- if ne .Name "extra_tags" "is_hub" "spoke_def" "org" }}
+  {{- if not (eq .Name "extra_tags" "is_hub" "spoke_def" "org") }}
   {{ .Name }} = try(local.local_vars.{{ .Name }}, {{ .DefaultValue }})
   {{- end }}
   {{- end }}

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@
 
 [![cloudopsworks][logo]](https://cloudopsworks.co/)
 
-# AWS IAM Users, Groups, and Policies Module
+# AWS IAM Users, Groups, Policies, and Access Key Rotation Module
+
+ [![Latest Release](https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-iam-user-groups.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups/releases/latest) [![Last Updated](https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-iam-user-groups.svg?style=for-the-badge)](https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups/commits)
 
 
-
-
-A comprehensive Terragrunt-ready module to manage AWS IAM identities and permissions at scale. It facilitates the creation of IAM users, groups, and policies with support for secret storage in AWS Secrets Manager and PGP encryption.
+Terragrunt-ready AWS IAM module for users, groups, managed policies, optional Secrets Manager storage, stable non-secret outputs, and an opt-in AWS Secrets Manager rotation configuration for IAM access keys backed by Lambda.
 
 
 ---
@@ -45,12 +45,16 @@ We have [*lots of terraform modules*][terraform_modules] that are Open Source an
 
 ## Introduction
 
-This module provides a standardized way to manage IAM Users, Groups, and Policies across multiple AWS accounts and environments. It integrates seamlessly with Terragrunt for infrastructure-as-code management. Key features include:
-- **IAM User Management**: Create users with console access, programmatic access keys, and CodeCommit credentials.
-- **IAM Group Management**: Define groups with explicit names or prefixes, attach AWS managed policies, module-defined policies, or inline policies.
-- **IAM Policy Management**: Define reusable policies that can be referenced by multiple groups.
-- **Secret Management**: Automatically store generated console passwords and access keys in AWS Secrets Manager.
-- **Security**: Support for PGP encryption for sensitive outputs, including loading keys from Secrets Manager.
+This module standardizes IAM user, group, and policy management across CloudOps Works AWS accounts and environments. It is designed for Terragrunt scaffolding and exposes stable non-secret metadata outputs for downstream modules and operations.
+
+Key capabilities include:
+- **IAM User Management**: Create IAM users with optional console access, Terraform-managed programmatic access keys, and CodeCommit credentials.
+- **IAM Group Management**: Create named or prefixed groups, reference existing groups, attach AWS managed policies, attach module-defined policies, and define inline group policies.
+- **IAM Policy Management**: Create reusable managed policies from structured statement definitions.
+- **Secret Storage**: Optionally store Terraform-generated console passwords and access keys in AWS Secrets Manager with PGP encryption support.
+- **Access Key Rotation**: Optionally configure AWS Secrets Manager rotation for selected module-managed users. Secrets Manager invokes a rotation Lambda that creates replacement IAM access keys and writes new key material directly into each user's secret.
+- **PGP-aware Rotation**: The module-created rotation Lambda receives the same resolved PGP public key contract used by Terraform-managed access keys (user-level `pgp_key` when present, otherwise `default_pgp_key`). When PGP is active, provide a Lambda layer containing `pgpy` so the Lambda stores encrypted replacement secrets.
+- **Operational Outputs**: Export user, group, membership, policy attachment, secret reference, and rotation metadata without returning access key secret values.
 
 ## Usage
 
@@ -59,203 +63,263 @@ This module provides a standardized way to manage IAM Users, Groups, and Policie
 Instead pin to the release tag (e.g. `?ref=vX.Y.Z`) of one of our [latest releases](https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups/releases).
 
 
-To use this module with Terragrunt, include it in your `terragrunt.hcl` file.
+## Terragrunt scaffolding workflow
 
-### Terragrunt Configuration
+Use Terragrunt's scaffold command so the module-generated `terragrunt.hcl`, `inputs.yaml`, and `local-tags.json` are created consistently.
+
+```sh
+# 1. Create and enter the target deployment directory
+mkdir -p prod/useast1/security/iam-user-groups
+cd prod/useast1/security/iam-user-groups
+
+# 2. Scaffold the module (do NOT use --working-dir)
+terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-iam-user-groups
+
+# 3. Edit inputs.yaml with deployment-specific values
+#    (all keys and comments are pre-populated from .boilerplate/inputs.yaml)
+vi inputs.yaml
+
+# 4. Apply
+terragrunt apply
+```
+
+## Generated `inputs.yaml`
+
+The scaffolded `inputs.yaml` contains all module-specific variables. Values such as `org`, `spoke_def`, `is_hub`, and `extra_tags` are supplied by the Terragrunt hierarchy and are intentionally not included here.
+
+```yaml
+# Module configuration
+
+secrets_manager_store: false # (Optional) Store Terraform-generated console passwords and access keys in AWS Secrets Manager under /<org_unit>/<environment_name>/<environment_type>. Default: false
+
+default_pgp_key: "" # (Optional) Default PGP key for console passwords and access keys; use raw armored PGP or "_aws:<secret_id>" to load from Secrets Manager. Default: ""
+
+access_key_rotation: # (Optional) Opt-in AWS Secrets Manager rotation control plane. Default: disabled
+  enabled: false # (Optional) Configure AWS Secrets Manager rotation for selected IAM users. Default: false
+  create_lambda: true # (Optional) Create the module IAM access key rotation Lambda. Set false to use lambda_arn. Default: true
+  lambda_arn: null # (Optional) Existing rotation Lambda ARN when create_lambda is false. Default: null
+  lambda_layer_arns: [] # (Optional) Lambda layer ARNs. Required when PGP is active with the module-created Lambda; include a layer with pgpy. Default: []
+  lambda_timeout: 60 # (Optional) Module-created Lambda timeout in seconds. Default: 60
+  lambda_memory_size: 256 # (Optional) Module-created Lambda memory size in MB. Default: 256
+  lambda_function_name: "" # (Optional) Module-created Lambda function name; blank uses <system_name_short>-iam-key-rotation and is truncated to 64 characters. Default: ""
+  lambda_role_name: "" # (Optional) Module-created Lambda IAM role name; blank uses <system_name_short>-iam-key-rotation-lambda and is truncated to 64 characters. Default: ""
+  log_retention_days: 30 # (Optional) CloudWatch log retention for the module-created Lambda. Default: 30
+  automatically_after_days: 90 # (Optional) Secrets Manager rotation interval when schedule_expression is not set. Default: rotate_after_days
+  schedule_expression: null # (Optional) Secrets Manager schedule expression such as "rate(30 days)"; do not set with automatically_after_days. Default: null
+  schedule_duration: null # (Optional) Rotation window duration such as "2h" when schedule_expression is set. Default: null
+  rotate_immediately: false # (Optional) Rotate immediately when AWS Secrets Manager rotation is configured. Default: false
+  rotate_after_days: 90 # (Optional) Lambda-side minimum age before creating a replacement key. Default: 90
+  grace_period_days: 7 # (Optional) Days before older non-current keys are deactivated during a rotation invocation. Default: 7
+  inactive_key_retention_days: 30 # (Optional) Additional days before deleting inactive keys when delete_inactive_keys is true. Default: 30
+  delete_inactive_keys: false # (Optional) Delete inactive keys after grace_period_days + inactive_key_retention_days. Default: false
+  users: [] # (Optional) Explicit module-managed user allowlist; when non-empty it overrides group-derived selection. Default: []
+  groups: [] # (Optional) Group references from users[*].groups used to derive selected users when users is empty. Default: []
+  exclude_users: [] # (Optional) Module-managed users removed from all-users, explicit, or group-derived scope. Default: []
+  create_secrets: true # (Optional) Create one Secrets Manager secret per selected user and configure rotation on it. Default: true
+  secret_prefix: "" # (Optional) Prefix for module-created Secrets Manager secrets; blank uses /<org_unit>/<environment_name>/<environment_type>/iam-user/access-key-rotation. Default: ""
+  secret_arns: {} # (Optional) Map of user name to existing Secrets Manager secret ARN/name when create_secrets is false or custom destinations are required. Default: {}
+  secret_kms_key_id: null # (Optional) KMS key ID/ARN for module-created rotation secrets and config. Default: null
+  secret_recovery_window_in_days: 30 # (Optional) Recovery window in days for module-created Secrets Manager secrets. Default: 30
+  config_secret_name: "" # (Optional) Name for the module-created Lambda configuration secret; blank uses <secret_prefix>/_rotation-config. Default: ""
+
+users: [] # (Optional) IAM users managed by this module. Default: []
+# users:
+#   - name: "username" # (Required) IAM user name.
+#     path: "/" # (Optional) IAM user path. Default: "/"
+#     pgp_key: "" # (Optional) User-specific PGP key; use raw armored PGP or "_aws:<secret_id>". Default: ""
+#     access_key_rotation_enabled: true # (Optional) Set false to opt this user out of module-level access_key_rotation selection. Default: true
+#     groups: ["developers"] # (Optional) Group memberships; use group.name for named groups or group.name_prefix for prefixed groups. Default: []
+#     access_keys: [] # (Optional) Terraform-managed access keys. Skipped automatically while this user is managed by access_key_rotation to avoid aws_iam_access_key recreation. Default: []
+#     console_access: null # (Optional) Console login profile configuration. Default: null
+#     code_commit: null # (Optional) CodeCommit HTTP/SSH credential configuration. Default: null
+
+groups: [] # (Optional) IAM groups managed or referenced by this module. Default: []
+# groups:
+#   - name: "developers" # (Optional) Explicit group name. Either name or name_prefix is required.
+#     name_prefix: "" # (Optional) Prefix for generated group name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+#     path: "/" # (Optional) IAM group path. Default: "/"
+#     existing: false # (Optional) Reference an existing IAM group by name instead of creating it. Default: false
+#     policy_attachments: [] # (Optional) Existing managed policy ARNs to attach. Default: []
+#     policy_refs: [] # (Optional) Names or prefixes of policies created by this module to attach. Default: []
+#     inline_policies: [] # (Optional) Inline policies to create on the group. Default: []
+
+policies: [] # (Optional) IAM managed policies created by this module. Default: []
+# policies:
+#   - name: "S3ReadOnly" # (Optional) Explicit policy name. Either name or name_prefix is required.
+#     name_prefix: "" # (Optional) Prefix for generated policy name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+#     statements: # (Required) IAM policy statements.
+#       - sid: "ListBuckets" # (Optional) Statement ID.
+#         effect: "Allow" # (Required) Statement effect. Valid values: "Allow", "Deny".
+#         actions: ["s3:ListAllMyBuckets"] # (Required) IAM actions.
+#         resources: ["*"] # (Required) IAM resources.
+#         conditions: [] # (Optional) IAM conditions with test, variable, and values. Default: []
+```
+
+## Generated `terragrunt.hcl`
+
+The scaffolded `terragrunt.hcl` wires `inputs.yaml` into the module inputs and merges tag files from the Terragrunt hierarchy.
+
 ```hcl
+locals {
+  local_vars  = yamldecode(file("./inputs.yaml"))
+  spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+  region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+  env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+  global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+
+  local_tags  = jsondecode(file("./local-tags.json"))
+  spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+  region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+  env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+  global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+
+  tags = merge(
+    local.global_tags,
+    local.env_tags,
+    local.region_tags,
+    local.spoke_tags,
+    local.local_tags
+  )
+}
+
+include "root" {
+  path = find_in_parent_folders("root.hcl")
+}
+
 terraform {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups.git?ref=v1.0.0"
+  source = "github.com/cloudopsworks/terraform-module-aws-iam-user-groups"
 }
 
 inputs = {
-  org = {
-    organization_name = "acme"
-    organization_unit = "platform"
-    environment_type  = "prod"
-    environment_name  = "main"
-  }
-
-  spoke_def = "001"
   is_hub    = false
+  org       = local.env_vars.org
+  spoke_def = local.spoke_vars.spoke
 
-  extra_tags = {
-    Project = "IAM-Management"
-  }
+  secrets_manager_store = try(local.local_vars.secrets_manager_store, false)
+  default_pgp_key       = try(local.local_vars.default_pgp_key, "")
+  access_key_rotation   = try(local.local_vars.access_key_rotation, {})
+  users                 = try(local.local_vars.users, [])
+  groups                = try(local.local_vars.groups, [])
+  policies              = try(local.local_vars.policies, [])
 
-  secrets_manager_store = true
-  default_pgp_key       = "_aws:prod/shared/pgp/public"
-
-  policies = [
-    {
-      name = "S3ReadOnly"
-      statements = [
-        {
-          effect    = "Allow"
-          actions   = ["s3:Get*", "s3:List*"]
-          resources = ["*"]
-        }
-      ]
-    }
-  ]
-
-  groups = [
-    {
-      name        = "developers"
-      policy_refs = ["S3ReadOnly"]
-    }
-  ]
-
-  users = [
-    {
-      name   = "john.doe"
-      groups = ["developers"]
-      console_access = {
-        enabled = true
-      }
-    }
-  ]
+  extra_tags = local.tags
 }
 ```
 
-### Variables Documentation (YAML Format)
-```yaml
-# Organization definition
-org:
-  organization_name: "acme" # (Required) Name of the organization
-  organization_unit: "platform" # (Required) Name of the organizational unit
-  environment_type: "prod" # (Required) Type of environment (e.g., prod, dev, staging)
-  environment_name: "main" # (Required) Name of the environment
+## Access key rotation operating model
 
-# Spoke definition
-spoke_def: "001" # (Optional) Spoke definition identifier. Default: "001"
+Rotation is disabled by default. When `access_key_rotation.enabled = true`, the module configures AWS Secrets Manager rotation for selected users. Secrets Manager invokes the rotation Lambda according to the configured rotation rules and calls the standard create, set, test, and finish rotation steps.
 
-# Hub/Spoke configuration
-is_hub: false # (Optional) Establish if this is a HUB or spoke configuration. Default: false
+The module-created Lambda:
 
-# Extra tags
-extra_tags: {} # (Optional) Additional tags to be applied to all resources. Default: {}
+- Creates a replacement IAM access key for the selected user when rotation is due.
+- Writes the replacement key material directly to that user's Secrets Manager secret.
+- Uses the resolved PGP public key from `default_pgp_key` or the user's `pgp_key` when PGP is configured.
+- Deactivates or deletes older non-current keys during rotation invocations according to `grace_period_days`, `inactive_key_retention_days`, and `delete_inactive_keys`.
 
-# Global settings
-secrets_manager_store: false # (Optional) When true, the module saves generated secrets into AWS Secrets Manager. Default: false
-default_pgp_key: "" # (Optional) Default PGP key used to encrypt sensitive values. Default: ""
+PGP behavior is explicit: if any selected user has `default_pgp_key` or `pgp_key` configured and `create_lambda = true`, `access_key_rotation.lambda_layer_arns` must include a Lambda layer that provides the `pgpy` Python package. Without PGP, no extra layer is required.
 
-# Users configuration
-users:
-  - name: "username" # (Required) IAM user name
-    path: "/" # (Optional) IAM path (e.g., "/service/"). Default: "/"
-    pgp_key: "armored_pgp_key" # (Optional) PGP key for this user. Default: ""
-    groups: ["group1"] # (Optional) List of groups the user belongs to. Default: []
-    access_keys: # (Optional) List of access keys to create. Default: []
-      - name: "key1" # (Required) Logical name for the key
-        status: "Active" # (Optional) Status of the key. Possible values: "Active", "Inactive". Default: "Active"
-    console_access: # (Optional) AWS Console access configuration. Default: null
-      enabled: true # (Required) When true, create login profile
-      password_length: 20 # (Optional) Password length. Default: 20
-      password_reset_required: true # (Optional) Whether password reset is required. Default: true
-    code_commit: # (Optional) AWS CodeCommit credentials. Default: null
-      http_credentials: true # (Optional) Create HTTP credentials. Default: false
-      ssh_credentials: true # (Optional) Create SSH credentials. Default: false
+Scope precedence is deterministic:
 
-# Groups configuration
-groups:
-  - name: "groupname" # (Optional) Named group (explicit name). Either name or name_prefix is REQUIRED.
-    path: "/" # (Optional) IAM path. Default: "/"
-    existing: false # (Optional) If true, reference existing IAM group by name. Default: false
-    policy_attachments: ["arn:aws:iam::aws:policy/ReadOnlyAccess"] # (Optional) Attach existing AWS managed policies by ARN. Default: []
-    policy_refs: ["policy1"] # (Optional) Attach policies created by this module via var.policies. Default: []
-    inline_policies: # (Optional) Inline policies to create and attach to this group. Default: []
-      - name: "inline-policy" # (Required) Name of the inline policy
-        statements: # (Required) List of policy statements
-          - sid: "sid1" # (Optional) Statement ID
-            effect: "Allow" # (Required) Effect. Possible values: "Allow", "Deny"
-            actions: ["s3:ListBucket"] # (Required) List of actions
-            resources: ["arn:aws:s3:::bucket-name"] # (Required) List of resources
-            conditions: # (Optional) List of conditions. Default: []
-              - test: "StringEquals" # (Required) Condition test
-                variable: "aws:PrincipalTag/Department" # (Required) Condition variable
-                values: ["IT"] # (Required) Condition values
+1. If `access_key_rotation.users` is non-empty, those module-managed users are selected.
+2. Otherwise, if `access_key_rotation.groups` is non-empty, users are derived from matching `users[*].groups` entries.
+3. Otherwise, all module-managed users are selected.
+4. `access_key_rotation.exclude_users` and `users[*].access_key_rotation_enabled = false` remove users from any of the above scopes.
 
-# Policies configuration
-policies:
-  - name: "policyname" # (Optional) Named policy. Either name or name_prefix is REQUIRED.
-    statements: # (Required) List of policy statements
-      - sid: "sid1" # (Optional) Statement ID
-        effect: "Allow" # (Required) Effect. Possible values: "Allow", "Deny"
-        actions: ["s3:ListBucket"] # (Required) List of actions
-        resources: ["arn:aws:s3:::bucket-name"] # (Required) List of resources
-```
+Secret values are never output by Terraform. Replacement key material is written by the Lambda directly to Secrets Manager. For users under rotation, the module intentionally skips Terraform-managed `users[*].access_keys` so `aws_iam_access_key` is not recreated after the rotation Lambda changes the IAM key set. Users that opt out of rotation keep the previous Terraform-managed access key behavior for backwards compatibility.
+
+Each configured user's Secrets Manager rotation schedule and Lambda association are maintained by `aws_secretsmanager_secret_rotation.access_key_rotation`; the per-user secret resource only creates or references the destination secret.
 
 ## Quick Start
 
-1.  **Install Terragrunt**: Ensure you have Terragrunt and Terraform installed.
-2.  **Create `terragrunt.hcl`**: Use the example above to create your configuration.
-3.  **Configure AWS Credentials**: Set up your AWS environment variables or profile.
-4.  **Initialize and Apply**:
-    ```bash
-    terragrunt init
-    terragrunt apply
-    ```
-5.  **Verify**: Check the AWS Console for the created users, groups, and policies. If `secrets_manager_store` was enabled, find the credentials in AWS Secrets Manager.
+1. Create the target deployment directory and run `terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-iam-user-groups` from inside it.
+2. Edit the generated `inputs.yaml` with users, groups, policies, and optional rotation settings.
+3. Keep `access_key_rotation.enabled = false` unless the deployment is ready for operational key rotation through AWS Secrets Manager rotation.
+4. If PGP is configured for selected users and `create_lambda = true`, provide `access_key_rotation.lambda_layer_arns` with a Lambda layer containing `pgpy`.
+5. Set `users[*].access_key_rotation_enabled = false` for any selected user that must keep Terraform-managed access keys.
+6. Run `terragrunt plan` and review created IAM users, groups, policies, secret destinations, Lambda resources, and Secrets Manager rotation configuration.
+7. Run `terragrunt apply`.
+8. If rotation is enabled, inspect the `access_key_rotation` output for Lambda/rotation metadata and read replacement secrets from Secrets Manager, not Terraform outputs.
 
 
 ## Examples
 
-### Full Terragrunt Example
-```hcl
-include "root" {
-  path = find_in_parent_folders()
-}
+## Basic IAM users, groups, and policies
 
-terraform {
-  source = "git::https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups.git?ref=v1.0.0"
-}
+```yaml
+secrets_manager_store: true
+default_pgp_key: "_aws:shared/security/pgp/public"
 
-inputs = {
-  org = {
-    organization_name = "cloudopsworks"
-    organization_unit = "operations"
-    environment_type  = "prod"
-    environment_name  = "shared"
-  }
+policies:
+  - name: "S3ReadOnly"
+    statements:
+      - effect: "Allow"
+        actions: ["s3:Get*", "s3:List*"]
+        resources: ["*"]
 
-  secrets_manager_store = true
+groups:
+  - name: "developers"
+    policy_refs: ["S3ReadOnly"]
 
-  policies = [
-    {
-      name = "AdministratorAccessCustom"
-      statements = [
-        {
-          effect    = "Allow"
-          actions   = ["*"]
-          resources = ["*"]
-        }
-      ]
-    }
-  ]
+users:
+  - name: "john.doe"
+    path: "/team/"
+    groups: ["developers"]
+    console_access:
+      enabled: true
+      password_length: 24
+      password_reset_required: true
+```
 
-  groups = [
-    {
-      name        = "admins"
-      policy_refs = ["AdministratorAccessCustom"]
-    }
-  ]
+## Enable Secrets Manager rotation for a group-derived scope
 
-  users = [
-    {
-      name   = "admin.user"
-      groups = ["admins"]
-      console_access = {
-        enabled = true
-        password_reset_required = true
-      }
-      access_keys = [
-        {
-          name = "primary"
-        }
-      ]
-    }
-  ]
-}
+```yaml
+access_key_rotation:
+  enabled: true
+  create_lambda: true
+  automatically_after_days: 90
+  rotate_after_days: 90
+  grace_period_days: 7
+  inactive_key_retention_days: 30
+  delete_inactive_keys: false
+  groups: ["automation"]
+  create_secrets: true
+
+groups:
+  - name: "automation"
+    policy_attachments:
+      - "arn:aws:iam::aws:policy/ReadOnlyAccess"
+
+users:
+  - name: "ci.bot"
+    groups: ["automation"]
+  - name: "breakglass.user"
+    groups: ["automation"]
+    access_key_rotation_enabled: false
+```
+
+## Enable rotation when PGP is active
+
+```yaml
+default_pgp_key: "_aws:shared/security/pgp/public"
+
+access_key_rotation:
+  enabled: true
+  create_lambda: true
+  lambda_layer_arns:
+    - "arn:aws:lambda:us-east-1:123456789012:layer:python-pgpy:1"
+  users: ["ci.bot"]
+```
+
+## Use pre-created Secrets Manager destinations
+
+```yaml
+access_key_rotation:
+  enabled: true
+  users: ["ci.bot"]
+  create_secrets: false
+  secret_arns:
+    ci.bot: "arn:aws:secretsmanager:us-east-1:123456789012:secret:iam/ci-bot-AbCdEf"
 ```
 
 
@@ -277,14 +341,16 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 
@@ -296,6 +362,7 @@ Available targets:
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_group.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
 | [aws_iam_group.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
@@ -307,48 +374,72 @@ Available targets:
 | [aws_iam_group_policy_attachment.prefixed_refs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_service_specific_credential.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_specific_credential) | resource |
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_group_membership.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
 | [aws_iam_user_login_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
+| [aws_lambda_function.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_secretsmanager_secret.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.access_key_rotation_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.user_login](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.user_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_rotation.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation) | resource |
+| [aws_secretsmanager_secret_version.access_key_rotation_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.user_login](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.user_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [archive_file.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_group.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_group) | data source |
 | [aws_iam_policy.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.access_key_rotation_lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.named_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.prefixed_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret_version.pgp_public_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_secretsmanager_secret_version.user_pgp_public_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_key_rotation"></a> [access\_key\_rotation](#input\_access\_key\_rotation) | Optional AWS Secrets Manager IAM access key rotation control plane. Disabled by default. See comments above for full schema. | `any` | `{}` | no |
 | <a name="input_default_pgp_key"></a> [default\_pgp\_key](#input\_default\_pgp\_key) | Default PGP key for encrypting secrets. Accepts raw armored PGP or "\_aws:<secret\_id>" to load it from AWS Secrets Manager. | `string` | `""` | no |
-| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | n/a | `map(string)` | `{}` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra tags to add to the resources | `map(string)` | `{}` | no |
 | <a name="input_groups"></a> [groups](#input\_groups) | List of IAM groups (named or prefixed). See comments above for full schema. | `any` | `[]` | no |
-| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Establish this is a HUB or spoke configuration | `bool` | `false` | no |
-| <a name="input_org"></a> [org](#input\_org) | n/a | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
+| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
+| <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of IAM policies (named or prefixed). See comments above for full schema and example. | `any` | `[]` | no |
 | <a name="input_secrets_manager_store"></a> [secrets\_manager\_store](#input\_secrets\_manager\_store) | Save secrets to the AWS Secrets Manager Store | `bool` | `false` | no |
-| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | n/a | `string` | `"001"` | no |
+| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
 | <a name="input_users"></a> [users](#input\_users) | List of IAM users (see comments above for full schema). | `any` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_groups"></a> [groups](#output\_groups) | n/a |
-| <a name="output_iam_access_keys"></a> [iam\_access\_keys](#output\_iam\_access\_keys) | n/a |
-| <a name="output_policies"></a> [policies](#output\_policies) | n/a |
-| <a name="output_users"></a> [users](#output\_users) | n/a |
+| <a name="output_access_key_rotation"></a> [access\_key\_rotation](#output\_access\_key\_rotation) | Non-secret metadata for the optional AWS Secrets Manager IAM access key rotation control plane. Secret values are not included. |
+| <a name="output_group_inline_policies"></a> [group\_inline\_policies](#output\_group\_inline\_policies) | Resolved IAM group inline policies keyed by module logical attachment name. |
+| <a name="output_group_policy_attachments"></a> [group\_policy\_attachments](#output\_group\_policy\_attachments) | Resolved IAM group managed-policy attachments, including external policy ARNs and module policy references. |
+| <a name="output_groups"></a> [groups](#output\_groups) | IAM group metadata for managed and referenced groups. Secret values are not included. |
+| <a name="output_groups_by_name"></a> [groups\_by\_name](#output\_groups\_by\_name) | IAM group metadata keyed by IAM group name for downstream module lookups. Secret values are not included. |
+| <a name="output_iam_access_key_metadata"></a> [iam\_access\_key\_metadata](#output\_iam\_access\_key\_metadata) | Non-secret IAM access key metadata keyed by logical key name. Secret access key values are not included. |
+| <a name="output_iam_access_keys"></a> [iam\_access\_keys](#output\_iam\_access\_keys) | Compatibility output for IAM access key metadata only; secret access key values are not included. Marked sensitive to preserve the historical output contract. |
+| <a name="output_policies"></a> [policies](#output\_policies) | IAM managed policy metadata created by this module. |
+| <a name="output_policies_by_name"></a> [policies\_by\_name](#output\_policies\_by\_name) | IAM managed policy metadata keyed by policy name for downstream module lookups. |
+| <a name="output_secrets_manager_secret_refs"></a> [secrets\_manager\_secret\_refs](#output\_secrets\_manager\_secret\_refs) | Secrets Manager secret references created by this module for console credentials and Terraform-managed access keys. Secret values are not included. |
+| <a name="output_user_group_memberships"></a> [user\_group\_memberships](#output\_user\_group\_memberships) | Resolved IAM group memberships keyed by IAM user name. |
+| <a name="output_users"></a> [users](#output\_users) | IAM user metadata created by this module. Secret values are not included. |
+| <a name="output_users_by_name"></a> [users\_by\_name](#output\_users\_by\_name) | IAM user metadata keyed by IAM user name for downstream module lookups. Secret values are not included. |
 
 
 
@@ -458,9 +549,9 @@ This project is maintained by [Cloud Ops Works LLC][website].
   [readme_footer_link]: https://cloudopsworks.co/readme/footer/link?utm_source=github&utm_medium=readme&utm_campaign=cloudopsworks/terraform-module-aws-iam-user-groups&utm_content=readme_footer_link
   [readme_commercial_support_img]: https://cloudopsworks.co/readme/commercial-support/img
   [readme_commercial_support_link]: https://cloudopsworks.co/readme/commercial-support/link?utm_source=github&utm_medium=readme&utm_campaign=cloudopsworks/terraform-module-aws-iam-user-groups&utm_content=readme_commercial_support_link
-  [share_twitter]: https://x.com/intent/tweet/?text=AWS+IAM+Users,+Groups,+and+Policies+Module&url=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
-  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=AWS+IAM+Users,+Groups,+and+Policies+Module&url=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
+  [share_twitter]: https://x.com/intent/tweet/?text=AWS+IAM+Users,+Groups,+Policies,+and+Access+Key+Rotation+Module&url=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
+  [share_linkedin]: https://www.linkedin.com/shareArticle?mini=true&title=AWS+IAM+Users,+Groups,+Policies,+and+Access+Key+Rotation+Module&url=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
   [share_reddit]: https://reddit.com/submit/?url=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
   [share_facebook]: https://facebook.com/sharer/sharer.php?u=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
-  [share_email]: mailto:?subject=AWS+IAM+Users,+Groups,+and+Policies+Module&body=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
+  [share_email]: mailto:?subject=AWS+IAM+Users,+Groups,+Policies,+and+Access+Key+Rotation+Module&body=https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups
   [beacon]: https://ga-beacon.cloudopsworks.co/G-QMZVYYN2VN/cloudopsworks/terraform-module-aws-iam-user-groups?pixel&cs=github&cm=readme&an=terraform-module-aws-iam-user-groups

--- a/README.md
+++ b/README.md
@@ -348,9 +348,9 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 

--- a/README.yaml
+++ b/README.yaml
@@ -1,5 +1,13 @@
-name: "AWS IAM Users, Groups, and Policies Module"
+name: "AWS IAM Users, Groups, Policies, and Access Key Rotation Module"
 #logo: logo/logo.jpg
+
+badges:
+  - name: Latest Release
+    image: https://img.shields.io/github/release/cloudopsworks/terraform-module-aws-iam-user-groups.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups/releases/latest
+  - name: Last Updated
+    image: https://img.shields.io/github/last-commit/cloudopsworks/terraform-module-aws-iam-user-groups.svg?style=for-the-badge
+    url: https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups/commits
 
 license: "APACHE2"
 
@@ -11,212 +19,276 @@ copyrights:
 github_repo: cloudopsworks/terraform-module-aws-iam-user-groups
 
 description: |-
-  A comprehensive Terragrunt-ready module to manage AWS IAM identities and permissions at scale. It facilitates the creation of IAM users, groups, and policies with support for secret storage in AWS Secrets Manager and PGP encryption.
+  Terragrunt-ready AWS IAM module for users, groups, managed policies, optional Secrets Manager storage, stable non-secret outputs, and an opt-in AWS Secrets Manager rotation configuration for IAM access keys backed by Lambda.
 
 introduction: |-
-  This module provides a standardized way to manage IAM Users, Groups, and Policies across multiple AWS accounts and environments. It integrates seamlessly with Terragrunt for infrastructure-as-code management. Key features include:
-  - **IAM User Management**: Create users with console access, programmatic access keys, and CodeCommit credentials.
-  - **IAM Group Management**: Define groups with explicit names or prefixes, attach AWS managed policies, module-defined policies, or inline policies.
-  - **IAM Policy Management**: Define reusable policies that can be referenced by multiple groups.
-  - **Secret Management**: Automatically store generated console passwords and access keys in AWS Secrets Manager.
-  - **Security**: Support for PGP encryption for sensitive outputs, including loading keys from Secrets Manager.
+  This module standardizes IAM user, group, and policy management across CloudOps Works AWS accounts and environments. It is designed for Terragrunt scaffolding and exposes stable non-secret metadata outputs for downstream modules and operations.
+
+  Key capabilities include:
+  - **IAM User Management**: Create IAM users with optional console access, Terraform-managed programmatic access keys, and CodeCommit credentials.
+  - **IAM Group Management**: Create named or prefixed groups, reference existing groups, attach AWS managed policies, attach module-defined policies, and define inline group policies.
+  - **IAM Policy Management**: Create reusable managed policies from structured statement definitions.
+  - **Secret Storage**: Optionally store Terraform-generated console passwords and access keys in AWS Secrets Manager with PGP encryption support.
+  - **Access Key Rotation**: Optionally configure AWS Secrets Manager rotation for selected module-managed users. Secrets Manager invokes a rotation Lambda that creates replacement IAM access keys and writes new key material directly into each user's secret.
+  - **PGP-aware Rotation**: The module-created rotation Lambda receives the same resolved PGP public key contract used by Terraform-managed access keys (user-level `pgp_key` when present, otherwise `default_pgp_key`). When PGP is active, provide a Lambda layer containing `pgpy` so the Lambda stores encrypted replacement secrets.
+  - **Operational Outputs**: Export user, group, membership, policy attachment, secret reference, and rotation metadata without returning access key secret values.
 
 usage: |-
-  To use this module with Terragrunt, include it in your `terragrunt.hcl` file.
+  ## Terragrunt scaffolding workflow
 
-  ### Terragrunt Configuration
+  Use Terragrunt's scaffold command so the module-generated `terragrunt.hcl`, `inputs.yaml`, and `local-tags.json` are created consistently.
+
+  ```sh
+  # 1. Create and enter the target deployment directory
+  mkdir -p prod/useast1/security/iam-user-groups
+  cd prod/useast1/security/iam-user-groups
+
+  # 2. Scaffold the module (do NOT use --working-dir)
+  terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-iam-user-groups
+
+  # 3. Edit inputs.yaml with deployment-specific values
+  #    (all keys and comments are pre-populated from .boilerplate/inputs.yaml)
+  vi inputs.yaml
+
+  # 4. Apply
+  terragrunt apply
+  ```
+
+  ## Generated `inputs.yaml`
+
+  The scaffolded `inputs.yaml` contains all module-specific variables. Values such as `org`, `spoke_def`, `is_hub`, and `extra_tags` are supplied by the Terragrunt hierarchy and are intentionally not included here.
+
+  ```yaml
+  # Module configuration
+
+  secrets_manager_store: false # (Optional) Store Terraform-generated console passwords and access keys in AWS Secrets Manager under /<org_unit>/<environment_name>/<environment_type>. Default: false
+
+  default_pgp_key: "" # (Optional) Default PGP key for console passwords and access keys; use raw armored PGP or "_aws:<secret_id>" to load from Secrets Manager. Default: ""
+
+  access_key_rotation: # (Optional) Opt-in AWS Secrets Manager rotation control plane. Default: disabled
+    enabled: false # (Optional) Configure AWS Secrets Manager rotation for selected IAM users. Default: false
+    create_lambda: true # (Optional) Create the module IAM access key rotation Lambda. Set false to use lambda_arn. Default: true
+    lambda_arn: null # (Optional) Existing rotation Lambda ARN when create_lambda is false. Default: null
+    lambda_layer_arns: [] # (Optional) Lambda layer ARNs. Required when PGP is active with the module-created Lambda; include a layer with pgpy. Default: []
+    lambda_timeout: 60 # (Optional) Module-created Lambda timeout in seconds. Default: 60
+    lambda_memory_size: 256 # (Optional) Module-created Lambda memory size in MB. Default: 256
+    lambda_function_name: "" # (Optional) Module-created Lambda function name; blank uses <system_name_short>-iam-key-rotation and is truncated to 64 characters. Default: ""
+    lambda_role_name: "" # (Optional) Module-created Lambda IAM role name; blank uses <system_name_short>-iam-key-rotation-lambda and is truncated to 64 characters. Default: ""
+    log_retention_days: 30 # (Optional) CloudWatch log retention for the module-created Lambda. Default: 30
+    automatically_after_days: 90 # (Optional) Secrets Manager rotation interval when schedule_expression is not set. Default: rotate_after_days
+    schedule_expression: null # (Optional) Secrets Manager schedule expression such as "rate(30 days)"; do not set with automatically_after_days. Default: null
+    schedule_duration: null # (Optional) Rotation window duration such as "2h" when schedule_expression is set. Default: null
+    rotate_immediately: false # (Optional) Rotate immediately when AWS Secrets Manager rotation is configured. Default: false
+    rotate_after_days: 90 # (Optional) Lambda-side minimum age before creating a replacement key. Default: 90
+    grace_period_days: 7 # (Optional) Days before older non-current keys are deactivated during a rotation invocation. Default: 7
+    inactive_key_retention_days: 30 # (Optional) Additional days before deleting inactive keys when delete_inactive_keys is true. Default: 30
+    delete_inactive_keys: false # (Optional) Delete inactive keys after grace_period_days + inactive_key_retention_days. Default: false
+    users: [] # (Optional) Explicit module-managed user allowlist; when non-empty it overrides group-derived selection. Default: []
+    groups: [] # (Optional) Group references from users[*].groups used to derive selected users when users is empty. Default: []
+    exclude_users: [] # (Optional) Module-managed users removed from all-users, explicit, or group-derived scope. Default: []
+    create_secrets: true # (Optional) Create one Secrets Manager secret per selected user and configure rotation on it. Default: true
+    secret_prefix: "" # (Optional) Prefix for module-created Secrets Manager secrets; blank uses /<org_unit>/<environment_name>/<environment_type>/iam-user/access-key-rotation. Default: ""
+    secret_arns: {} # (Optional) Map of user name to existing Secrets Manager secret ARN/name when create_secrets is false or custom destinations are required. Default: {}
+    secret_kms_key_id: null # (Optional) KMS key ID/ARN for module-created rotation secrets and config. Default: null
+    secret_recovery_window_in_days: 30 # (Optional) Recovery window in days for module-created Secrets Manager secrets. Default: 30
+    config_secret_name: "" # (Optional) Name for the module-created Lambda configuration secret; blank uses <secret_prefix>/_rotation-config. Default: ""
+
+  users: [] # (Optional) IAM users managed by this module. Default: []
+  # users:
+  #   - name: "username" # (Required) IAM user name.
+  #     path: "/" # (Optional) IAM user path. Default: "/"
+  #     pgp_key: "" # (Optional) User-specific PGP key; use raw armored PGP or "_aws:<secret_id>". Default: ""
+  #     access_key_rotation_enabled: true # (Optional) Set false to opt this user out of module-level access_key_rotation selection. Default: true
+  #     groups: ["developers"] # (Optional) Group memberships; use group.name for named groups or group.name_prefix for prefixed groups. Default: []
+  #     access_keys: [] # (Optional) Terraform-managed access keys. Skipped automatically while this user is managed by access_key_rotation to avoid aws_iam_access_key recreation. Default: []
+  #     console_access: null # (Optional) Console login profile configuration. Default: null
+  #     code_commit: null # (Optional) CodeCommit HTTP/SSH credential configuration. Default: null
+
+  groups: [] # (Optional) IAM groups managed or referenced by this module. Default: []
+  # groups:
+  #   - name: "developers" # (Optional) Explicit group name. Either name or name_prefix is required.
+  #     name_prefix: "" # (Optional) Prefix for generated group name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+  #     path: "/" # (Optional) IAM group path. Default: "/"
+  #     existing: false # (Optional) Reference an existing IAM group by name instead of creating it. Default: false
+  #     policy_attachments: [] # (Optional) Existing managed policy ARNs to attach. Default: []
+  #     policy_refs: [] # (Optional) Names or prefixes of policies created by this module to attach. Default: []
+  #     inline_policies: [] # (Optional) Inline policies to create on the group. Default: []
+
+  policies: [] # (Optional) IAM managed policies created by this module. Default: []
+  # policies:
+  #   - name: "S3ReadOnly" # (Optional) Explicit policy name. Either name or name_prefix is required.
+  #     name_prefix: "" # (Optional) Prefix for generated policy name "<name_prefix>-<system_name>". Either name or name_prefix is required.
+  #     statements: # (Required) IAM policy statements.
+  #       - sid: "ListBuckets" # (Optional) Statement ID.
+  #         effect: "Allow" # (Required) Statement effect. Valid values: "Allow", "Deny".
+  #         actions: ["s3:ListAllMyBuckets"] # (Required) IAM actions.
+  #         resources: ["*"] # (Required) IAM resources.
+  #         conditions: [] # (Optional) IAM conditions with test, variable, and values. Default: []
+  ```
+
+  ## Generated `terragrunt.hcl`
+
+  The scaffolded `terragrunt.hcl` wires `inputs.yaml` into the module inputs and merges tag files from the Terragrunt hierarchy.
+
   ```hcl
+  locals {
+    local_vars  = yamldecode(file("./inputs.yaml"))
+    spoke_vars  = yamldecode(file(find_in_parent_folders("spoke-inputs.yaml")))
+    region_vars = yamldecode(file(find_in_parent_folders("region-inputs.yaml")))
+    env_vars    = yamldecode(file(find_in_parent_folders("env-inputs.yaml")))
+    global_vars = yamldecode(file(find_in_parent_folders("global-inputs.yaml")))
+
+    local_tags  = jsondecode(file("./local-tags.json"))
+    spoke_tags  = jsondecode(file(find_in_parent_folders("spoke-tags.json")))
+    region_tags = jsondecode(file(find_in_parent_folders("region-tags.json")))
+    env_tags    = jsondecode(file(find_in_parent_folders("env-tags.json")))
+    global_tags = jsondecode(file(find_in_parent_folders("global-tags.json")))
+
+    tags = merge(
+      local.global_tags,
+      local.env_tags,
+      local.region_tags,
+      local.spoke_tags,
+      local.local_tags
+    )
+  }
+
+  include "root" {
+    path = find_in_parent_folders("root.hcl")
+  }
+
   terraform {
-    source = "git::https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups.git?ref=v1.0.0"
+    source = "github.com/cloudopsworks/terraform-module-aws-iam-user-groups"
   }
 
   inputs = {
-    org = {
-      organization_name = "acme"
-      organization_unit = "platform"
-      environment_type  = "prod"
-      environment_name  = "main"
-    }
-
-    spoke_def = "001"
     is_hub    = false
+    org       = local.env_vars.org
+    spoke_def = local.spoke_vars.spoke
 
-    extra_tags = {
-      Project = "IAM-Management"
-    }
+    secrets_manager_store = try(local.local_vars.secrets_manager_store, false)
+    default_pgp_key       = try(local.local_vars.default_pgp_key, "")
+    access_key_rotation   = try(local.local_vars.access_key_rotation, {})
+    users                 = try(local.local_vars.users, [])
+    groups                = try(local.local_vars.groups, [])
+    policies              = try(local.local_vars.policies, [])
 
-    secrets_manager_store = true
-    default_pgp_key       = "_aws:prod/shared/pgp/public"
-
-    policies = [
-      {
-        name = "S3ReadOnly"
-        statements = [
-          {
-            effect    = "Allow"
-            actions   = ["s3:Get*", "s3:List*"]
-            resources = ["*"]
-          }
-        ]
-      }
-    ]
-
-    groups = [
-      {
-        name        = "developers"
-        policy_refs = ["S3ReadOnly"]
-      }
-    ]
-
-    users = [
-      {
-        name   = "john.doe"
-        groups = ["developers"]
-        console_access = {
-          enabled = true
-        }
-      }
-    ]
+    extra_tags = local.tags
   }
   ```
 
-  ### Variables Documentation (YAML Format)
-  ```yaml
-  # Organization definition
-  org:
-    organization_name: "acme" # (Required) Name of the organization
-    organization_unit: "platform" # (Required) Name of the organizational unit
-    environment_type: "prod" # (Required) Type of environment (e.g., prod, dev, staging)
-    environment_name: "main" # (Required) Name of the environment
+  ## Access key rotation operating model
 
-  # Spoke definition
-  spoke_def: "001" # (Optional) Spoke definition identifier. Default: "001"
+  Rotation is disabled by default. When `access_key_rotation.enabled = true`, the module configures AWS Secrets Manager rotation for selected users. Secrets Manager invokes the rotation Lambda according to the configured rotation rules and calls the standard create, set, test, and finish rotation steps.
 
-  # Hub/Spoke configuration
-  is_hub: false # (Optional) Establish if this is a HUB or spoke configuration. Default: false
+  The module-created Lambda:
 
-  # Extra tags
-  extra_tags: {} # (Optional) Additional tags to be applied to all resources. Default: {}
+  - Creates a replacement IAM access key for the selected user when rotation is due.
+  - Writes the replacement key material directly to that user's Secrets Manager secret.
+  - Uses the resolved PGP public key from `default_pgp_key` or the user's `pgp_key` when PGP is configured.
+  - Deactivates or deletes older non-current keys during rotation invocations according to `grace_period_days`, `inactive_key_retention_days`, and `delete_inactive_keys`.
 
-  # Global settings
-  secrets_manager_store: false # (Optional) When true, the module saves generated secrets into AWS Secrets Manager. Default: false
-  default_pgp_key: "" # (Optional) Default PGP key used to encrypt sensitive values. Default: ""
+  PGP behavior is explicit: if any selected user has `default_pgp_key` or `pgp_key` configured and `create_lambda = true`, `access_key_rotation.lambda_layer_arns` must include a Lambda layer that provides the `pgpy` Python package. Without PGP, no extra layer is required.
 
-  # Users configuration
-  users:
-    - name: "username" # (Required) IAM user name
-      path: "/" # (Optional) IAM path (e.g., "/service/"). Default: "/"
-      pgp_key: "armored_pgp_key" # (Optional) PGP key for this user. Default: ""
-      groups: ["group1"] # (Optional) List of groups the user belongs to. Default: []
-      access_keys: # (Optional) List of access keys to create. Default: []
-        - name: "key1" # (Required) Logical name for the key
-          status: "Active" # (Optional) Status of the key. Possible values: "Active", "Inactive". Default: "Active"
-      console_access: # (Optional) AWS Console access configuration. Default: null
-        enabled: true # (Required) When true, create login profile
-        password_length: 20 # (Optional) Password length. Default: 20
-        password_reset_required: true # (Optional) Whether password reset is required. Default: true
-      code_commit: # (Optional) AWS CodeCommit credentials. Default: null
-        http_credentials: true # (Optional) Create HTTP credentials. Default: false
-        ssh_credentials: true # (Optional) Create SSH credentials. Default: false
+  Scope precedence is deterministic:
 
-  # Groups configuration
-  groups:
-    - name: "groupname" # (Optional) Named group (explicit name). Either name or name_prefix is REQUIRED.
-      path: "/" # (Optional) IAM path. Default: "/"
-      existing: false # (Optional) If true, reference existing IAM group by name. Default: false
-      policy_attachments: ["arn:aws:iam::aws:policy/ReadOnlyAccess"] # (Optional) Attach existing AWS managed policies by ARN. Default: []
-      policy_refs: ["policy1"] # (Optional) Attach policies created by this module via var.policies. Default: []
-      inline_policies: # (Optional) Inline policies to create and attach to this group. Default: []
-        - name: "inline-policy" # (Required) Name of the inline policy
-          statements: # (Required) List of policy statements
-            - sid: "sid1" # (Optional) Statement ID
-              effect: "Allow" # (Required) Effect. Possible values: "Allow", "Deny"
-              actions: ["s3:ListBucket"] # (Required) List of actions
-              resources: ["arn:aws:s3:::bucket-name"] # (Required) List of resources
-              conditions: # (Optional) List of conditions. Default: []
-                - test: "StringEquals" # (Required) Condition test
-                  variable: "aws:PrincipalTag/Department" # (Required) Condition variable
-                  values: ["IT"] # (Required) Condition values
+  1. If `access_key_rotation.users` is non-empty, those module-managed users are selected.
+  2. Otherwise, if `access_key_rotation.groups` is non-empty, users are derived from matching `users[*].groups` entries.
+  3. Otherwise, all module-managed users are selected.
+  4. `access_key_rotation.exclude_users` and `users[*].access_key_rotation_enabled = false` remove users from any of the above scopes.
 
-  # Policies configuration
-  policies:
-    - name: "policyname" # (Optional) Named policy. Either name or name_prefix is REQUIRED.
-      statements: # (Required) List of policy statements
-        - sid: "sid1" # (Optional) Statement ID
-          effect: "Allow" # (Required) Effect. Possible values: "Allow", "Deny"
-          actions: ["s3:ListBucket"] # (Required) List of actions
-          resources: ["arn:aws:s3:::bucket-name"] # (Required) List of resources
-  ```
+  Secret values are never output by Terraform. Replacement key material is written by the Lambda directly to Secrets Manager. For users under rotation, the module intentionally skips Terraform-managed `users[*].access_keys` so `aws_iam_access_key` is not recreated after the rotation Lambda changes the IAM key set. Users that opt out of rotation keep the previous Terraform-managed access key behavior for backwards compatibility.
+
+  Each configured user's Secrets Manager rotation schedule and Lambda association are maintained by `aws_secretsmanager_secret_rotation.access_key_rotation`; the per-user secret resource only creates or references the destination secret.
 
 examples: |-
-  ### Full Terragrunt Example
-  ```hcl
-  include "root" {
-    path = find_in_parent_folders()
-  }
+  ## Basic IAM users, groups, and policies
 
-  terraform {
-    source = "git::https://github.com/cloudopsworks/terraform-module-aws-iam-user-groups.git?ref=v1.0.0"
-  }
+  ```yaml
+  secrets_manager_store: true
+  default_pgp_key: "_aws:shared/security/pgp/public"
 
-  inputs = {
-    org = {
-      organization_name = "cloudopsworks"
-      organization_unit = "operations"
-      environment_type  = "prod"
-      environment_name  = "shared"
-    }
+  policies:
+    - name: "S3ReadOnly"
+      statements:
+        - effect: "Allow"
+          actions: ["s3:Get*", "s3:List*"]
+          resources: ["*"]
 
-    secrets_manager_store = true
+  groups:
+    - name: "developers"
+      policy_refs: ["S3ReadOnly"]
 
-    policies = [
-      {
-        name = "AdministratorAccessCustom"
-        statements = [
-          {
-            effect    = "Allow"
-            actions   = ["*"]
-            resources = ["*"]
-          }
-        ]
-      }
-    ]
+  users:
+    - name: "john.doe"
+      path: "/team/"
+      groups: ["developers"]
+      console_access:
+        enabled: true
+        password_length: 24
+        password_reset_required: true
+  ```
 
-    groups = [
-      {
-        name        = "admins"
-        policy_refs = ["AdministratorAccessCustom"]
-      }
-    ]
+  ## Enable Secrets Manager rotation for a group-derived scope
 
-    users = [
-      {
-        name   = "admin.user"
-        groups = ["admins"]
-        console_access = {
-          enabled = true
-          password_reset_required = true
-        }
-        access_keys = [
-          {
-            name = "primary"
-          }
-        ]
-      }
-    ]
-  }
+  ```yaml
+  access_key_rotation:
+    enabled: true
+    create_lambda: true
+    automatically_after_days: 90
+    rotate_after_days: 90
+    grace_period_days: 7
+    inactive_key_retention_days: 30
+    delete_inactive_keys: false
+    groups: ["automation"]
+    create_secrets: true
+
+  groups:
+    - name: "automation"
+      policy_attachments:
+        - "arn:aws:iam::aws:policy/ReadOnlyAccess"
+
+  users:
+    - name: "ci.bot"
+      groups: ["automation"]
+    - name: "breakglass.user"
+      groups: ["automation"]
+      access_key_rotation_enabled: false
+  ```
+
+  ## Enable rotation when PGP is active
+
+  ```yaml
+  default_pgp_key: "_aws:shared/security/pgp/public"
+
+  access_key_rotation:
+    enabled: true
+    create_lambda: true
+    lambda_layer_arns:
+      - "arn:aws:lambda:us-east-1:123456789012:layer:python-pgpy:1"
+    users: ["ci.bot"]
+  ```
+
+  ## Use pre-created Secrets Manager destinations
+
+  ```yaml
+  access_key_rotation:
+    enabled: true
+    users: ["ci.bot"]
+    create_secrets: false
+    secret_arns:
+      ci.bot: "arn:aws:secretsmanager:us-east-1:123456789012:secret:iam/ci-bot-AbCdEf"
   ```
 
 quickstart: |-
-  1.  **Install Terragrunt**: Ensure you have Terragrunt and Terraform installed.
-  2.  **Create `terragrunt.hcl`**: Use the example above to create your configuration.
-  3.  **Configure AWS Credentials**: Set up your AWS environment variables or profile.
-  4.  **Initialize and Apply**:
-      ```bash
-      terragrunt init
-      terragrunt apply
-      ```
-  5.  **Verify**: Check the AWS Console for the created users, groups, and policies. If `secrets_manager_store` was enabled, find the credentials in AWS Secrets Manager.
+  1. Create the target deployment directory and run `terragrunt scaffold github.com/cloudopsworks/terraform-module-aws-iam-user-groups` from inside it.
+  2. Edit the generated `inputs.yaml` with users, groups, policies, and optional rotation settings.
+  3. Keep `access_key_rotation.enabled = false` unless the deployment is ready for operational key rotation through AWS Secrets Manager rotation.
+  4. If PGP is configured for selected users and `create_lambda = true`, provide `access_key_rotation.lambda_layer_arns` with a Lambda layer containing `pgpy`.
+  5. Set `users[*].access_key_rotation_enabled = false` for any selected user that must keep Terraform-managed access keys.
+  6. Run `terragrunt plan` and review created IAM users, groups, policies, secret destinations, Lambda resources, and Secrets Manager rotation configuration.
+  7. Run `terragrunt apply`.
+  8. If rotation is enabled, inspect the `access_key_rotation` output for Lambda/rotation metadata and read replacement secrets from Secrets Manager, not Terraform outputs.
 
 include:
   - "docs/targets.md"

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,14 +3,16 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.4 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | ~> 2.7 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 6.35 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.4 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
 
 ## Modules
 
@@ -22,6 +24,7 @@
 
 | Name | Type |
 |------|------|
+| [aws_cloudwatch_log_group.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_access_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_group.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
 | [aws_iam_group.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group) | resource |
@@ -33,45 +36,69 @@
 | [aws_iam_group_policy_attachment.prefixed_refs](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_group_policy_attachment) | resource |
 | [aws_iam_policy.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
 | [aws_iam_service_specific_credential.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_service_specific_credential) | resource |
 | [aws_iam_user.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
 | [aws_iam_user_group_membership.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_group_membership) | resource |
 | [aws_iam_user_login_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_login_profile) | resource |
 | [aws_iam_user_ssh_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_ssh_key) | resource |
+| [aws_lambda_function.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_function) | resource |
+| [aws_lambda_permission.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/lambda_permission) | resource |
+| [aws_secretsmanager_secret.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret.access_key_rotation_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.user_login](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.user_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
+| [aws_secretsmanager_secret_rotation.access_key_rotation](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_rotation) | resource |
+| [aws_secretsmanager_secret_version.access_key_rotation_config](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.user_login](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.user_secret](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [tls_private_key.this](https://registry.terraform.io/providers/hashicorp/tls/latest/docs/resources/private_key) | resource |
+| [archive_file.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_group.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_group) | data source |
 | [aws_iam_policy.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
 | [aws_iam_policy.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy) | data source |
+| [aws_iam_policy_document.access_key_rotation_lambda](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.access_key_rotation_lambda_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.named](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.named_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.prefixed](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.prefixed_inline](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
 | [aws_secretsmanager_secret_version.pgp_public_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
+| [aws_secretsmanager_secret_version.user_pgp_public_key](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_access_key_rotation"></a> [access\_key\_rotation](#input\_access\_key\_rotation) | Optional AWS Secrets Manager IAM access key rotation control plane. Disabled by default. See comments above for full schema. | `any` | `{}` | no |
 | <a name="input_default_pgp_key"></a> [default\_pgp\_key](#input\_default\_pgp\_key) | Default PGP key for encrypting secrets. Accepts raw armored PGP or "\_aws:<secret\_id>" to load it from AWS Secrets Manager. | `string` | `""` | no |
-| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | n/a | `map(string)` | `{}` | no |
+| <a name="input_extra_tags"></a> [extra\_tags](#input\_extra\_tags) | Extra tags to add to the resources | `map(string)` | `{}` | no |
 | <a name="input_groups"></a> [groups](#input\_groups) | List of IAM groups (named or prefixed). See comments above for full schema. | `any` | `[]` | no |
-| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Establish this is a HUB or spoke configuration | `bool` | `false` | no |
-| <a name="input_org"></a> [org](#input\_org) | n/a | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
+| <a name="input_is_hub"></a> [is\_hub](#input\_is\_hub) | Is this a hub or spoke configuration? | `bool` | `false` | no |
+| <a name="input_org"></a> [org](#input\_org) | Organization details | <pre>object({<br/>    organization_name = string<br/>    organization_unit = string<br/>    environment_type  = string<br/>    environment_name  = string<br/>  })</pre> | n/a | yes |
 | <a name="input_policies"></a> [policies](#input\_policies) | List of IAM policies (named or prefixed). See comments above for full schema and example. | `any` | `[]` | no |
 | <a name="input_secrets_manager_store"></a> [secrets\_manager\_store](#input\_secrets\_manager\_store) | Save secrets to the AWS Secrets Manager Store | `bool` | `false` | no |
-| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | n/a | `string` | `"001"` | no |
+| <a name="input_spoke_def"></a> [spoke\_def](#input\_spoke\_def) | Spoke ID Number, must be a 3 digit number | `string` | `"001"` | no |
 | <a name="input_users"></a> [users](#input\_users) | List of IAM users (see comments above for full schema). | `any` | `[]` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_groups"></a> [groups](#output\_groups) | n/a |
-| <a name="output_iam_access_keys"></a> [iam\_access\_keys](#output\_iam\_access\_keys) | n/a |
-| <a name="output_policies"></a> [policies](#output\_policies) | n/a |
-| <a name="output_users"></a> [users](#output\_users) | n/a |
+| <a name="output_access_key_rotation"></a> [access\_key\_rotation](#output\_access\_key\_rotation) | Non-secret metadata for the optional AWS Secrets Manager IAM access key rotation control plane. Secret values are not included. |
+| <a name="output_group_inline_policies"></a> [group\_inline\_policies](#output\_group\_inline\_policies) | Resolved IAM group inline policies keyed by module logical attachment name. |
+| <a name="output_group_policy_attachments"></a> [group\_policy\_attachments](#output\_group\_policy\_attachments) | Resolved IAM group managed-policy attachments, including external policy ARNs and module policy references. |
+| <a name="output_groups"></a> [groups](#output\_groups) | IAM group metadata for managed and referenced groups. Secret values are not included. |
+| <a name="output_groups_by_name"></a> [groups\_by\_name](#output\_groups\_by\_name) | IAM group metadata keyed by IAM group name for downstream module lookups. Secret values are not included. |
+| <a name="output_iam_access_key_metadata"></a> [iam\_access\_key\_metadata](#output\_iam\_access\_key\_metadata) | Non-secret IAM access key metadata keyed by logical key name. Secret access key values are not included. |
+| <a name="output_iam_access_keys"></a> [iam\_access\_keys](#output\_iam\_access\_keys) | Compatibility output for IAM access key metadata only; secret access key values are not included. Marked sensitive to preserve the historical output contract. |
+| <a name="output_policies"></a> [policies](#output\_policies) | IAM managed policy metadata created by this module. |
+| <a name="output_policies_by_name"></a> [policies\_by\_name](#output\_policies\_by\_name) | IAM managed policy metadata keyed by policy name for downstream module lookups. |
+| <a name="output_secrets_manager_secret_refs"></a> [secrets\_manager\_secret\_refs](#output\_secrets\_manager\_secret\_refs) | Secrets Manager secret references created by this module for console credentials and Terraform-managed access keys. Secret values are not included. |
+| <a name="output_user_group_memberships"></a> [user\_group\_memberships](#output\_user\_group\_memberships) | Resolved IAM group memberships keyed by IAM user name. |
+| <a name="output_users"></a> [users](#output\_users) | IAM user metadata created by this module. Secret values are not included. |
+| <a name="output_users_by_name"></a> [users\_by\_name](#output\_users\_by\_name) | IAM user metadata keyed by IAM user name for downstream module lookups. Secret values are not included. |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -10,9 +10,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | 2.8.0 |
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.51.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.3.0 |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | ~> 2.7 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 6.35 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | n/a |
 
 ## Modules
 

--- a/lambda/iam_access_key_rotation.py
+++ b/lambda/iam_access_key_rotation.py
@@ -1,0 +1,272 @@
+"""AWS Secrets Manager rotation Lambda for IAM user access keys.
+
+The function implements the Secrets Manager rotation protocol for module-managed
+IAM users. It writes replacement access key material only to Secrets Manager. If
+PGP is configured for a user, the secret access key is PGP-encrypted before it is
+stored; attach a Lambda layer that provides the `pgpy` package when PGP is used.
+"""
+
+import datetime
+import json
+import os
+
+import boto3
+from botocore.exceptions import ClientError
+
+try:
+    import pgpy
+except ImportError:  # PGP is optional unless configured for a rotated user.
+    pgpy = None
+
+secretsmanager = boto3.client("secretsmanager")
+iam = boto3.client("iam")
+
+CONFIG_SECRET_ID = os.environ["ROTATION_CONFIG_SECRET_ID"]
+
+
+def handler(event, context):
+    """Dispatch a Secrets Manager rotation step."""
+    secret_id = event["SecretId"]
+    token = event["ClientRequestToken"]
+    step = event["Step"].replace("_", "").lower()
+
+    metadata = secretsmanager.describe_secret(SecretId=secret_id)
+    if not metadata.get("RotationEnabled"):
+        raise ValueError(f"Secret {secret_id} is not enabled for rotation")
+
+    versions = metadata.get("VersionIdsToStages", {})
+    if token not in versions:
+        raise ValueError(f"Secret version {token} has no stage for {secret_id}")
+    if "AWSCURRENT" in versions[token]:
+        return
+    if "AWSPENDING" not in versions[token]:
+        raise ValueError(f"Secret version {token} is not staged as AWSPENDING")
+
+    config = _load_config()
+    user_name, user_config = _user_config_for_secret(config, secret_id, metadata)
+
+    if step == "createsecret":
+        _create_secret(secret_id, token, user_name, user_config, config)
+    elif step == "setsecret":
+        _set_secret(secret_id, token)
+    elif step == "testsecret":
+        _test_secret(secret_id, token, user_name)
+    elif step == "finishsecret":
+        _finish_secret(secret_id, token, user_name, config)
+    else:
+        raise ValueError(f"Unsupported rotation step: {event['Step']}")
+
+
+def _load_config():
+    response = secretsmanager.get_secret_value(SecretId=CONFIG_SECRET_ID)
+    return json.loads(response.get("SecretString") or "{}")
+
+
+def _user_config_for_secret(config, secret_id, metadata):
+    secret_arn = metadata.get("ARN", secret_id)
+    secret_name = metadata.get("Name", secret_id)
+    for user_name, user_config in config.get("users", {}).items():
+        candidates = {
+            value
+            for value in [
+                user_config.get("secret_id"),
+                user_config.get("secret_arn"),
+                user_config.get("secret_name"),
+            ]
+            if value
+        }
+        if secret_id in candidates or secret_arn in candidates or secret_name in candidates:
+            return user_name, user_config
+    raise ValueError(f"No rotation config entry found for secret {secret_id}")
+
+
+def _create_secret(secret_id, token, user_name, user_config, config):
+    if _version_exists(secret_id, token, "AWSPENDING"):
+        return
+
+    current_secret = _get_secret_json(secret_id, "AWSCURRENT")
+    rotate_after_days = int(config.get("rotate_after_days", 90))
+    if current_secret and not _rotation_due(current_secret, rotate_after_days):
+        pending_secret = dict(current_secret)
+        pending_secret["rotation_noop"] = True
+        pending_secret["rotation_checked_at"] = _now().isoformat()
+        secretsmanager.put_secret_value(
+            SecretId=secret_id,
+            ClientRequestToken=token,
+            SecretString=json.dumps(pending_secret, default=str),
+            VersionStages=["AWSPENDING"],
+        )
+        return
+
+    _cleanup_old_keys(user_name, current_secret, config)
+    keys = _list_access_keys(user_name)
+    if len(keys) >= 2:
+        raise RuntimeError(f"IAM user {user_name} already has two access keys")
+
+    new_key = iam.create_access_key(UserName=user_name)["AccessKey"]
+    try:
+        pending_secret = _secret_payload(user_name, new_key, current_secret, user_config)
+        secretsmanager.put_secret_value(
+            SecretId=secret_id,
+            ClientRequestToken=token,
+            SecretString=json.dumps(pending_secret, default=str),
+            VersionStages=["AWSPENDING"],
+        )
+    except Exception:
+        iam.delete_access_key(UserName=user_name, AccessKeyId=new_key["AccessKeyId"])
+        raise
+
+
+def _set_secret(secret_id, token):
+    # IAM access keys become active when created. This step verifies the pending
+    # version exists and intentionally performs no additional external mutation.
+    _get_secret_json(secret_id, "AWSPENDING", token)
+
+
+def _test_secret(secret_id, token, user_name):
+    pending_secret = _get_secret_json(secret_id, "AWSPENDING", token)
+    access_key_id = pending_secret["access_key_id"]
+
+    if pending_secret.get("pgp") == "yes":
+        keys = _list_access_keys(user_name)
+        if not any(key["AccessKeyId"] == access_key_id and key["Status"] == "Active" for key in keys):
+            raise RuntimeError(f"Pending PGP-encrypted key {access_key_id} is not active")
+        return
+
+    secret_access_key = pending_secret.get("secret_access_key")
+    if not secret_access_key:
+        raise RuntimeError("Pending secret is missing secret_access_key")
+
+    sts = boto3.client(
+        "sts",
+        aws_access_key_id=access_key_id,
+        aws_secret_access_key=secret_access_key,
+    )
+    sts.get_caller_identity()
+
+
+def _finish_secret(secret_id, token, user_name, config):
+    metadata = secretsmanager.describe_secret(SecretId=secret_id)
+    current_version = None
+    for version, stages in metadata.get("VersionIdsToStages", {}).items():
+        if "AWSCURRENT" in stages:
+            if version == token:
+                return
+            current_version = version
+            break
+
+    secretsmanager.update_secret_version_stage(
+        SecretId=secret_id,
+        VersionStage="AWSCURRENT",
+        MoveToVersionId=token,
+        RemoveFromVersionId=current_version,
+    )
+
+    current_secret = _get_secret_json(secret_id, "AWSCURRENT")
+    _cleanup_old_keys(user_name, current_secret, config)
+
+
+def _get_secret_json(secret_id, version_stage, version_id=None):
+    try:
+        kwargs = {"SecretId": secret_id, "VersionStage": version_stage}
+        if version_id:
+            kwargs["VersionId"] = version_id
+        response = secretsmanager.get_secret_value(**kwargs)
+        return json.loads(response.get("SecretString") or "{}")
+    except ClientError as exc:
+        if exc.response.get("Error", {}).get("Code") in {"ResourceNotFoundException", "InvalidRequestException"}:
+            return None
+        raise
+
+
+def _version_exists(secret_id, version_id, version_stage):
+    return _get_secret_json(secret_id, version_stage, version_id) is not None
+
+
+def _secret_payload(user_name, access_key, current_secret, user_config):
+    secret_access_key = access_key["SecretAccessKey"]
+    pgp_key = user_config.get("pgp_key") or ""
+    payload = {
+        "user_name": user_name,
+        "access_key_id": access_key["AccessKeyId"],
+        "created_at": access_key["CreateDate"].isoformat(),
+        "rotation_source": "terraform-module-aws-iam-user-groups",
+        "previous_access_key_id": (current_secret or {}).get("access_key_id"),
+    }
+
+    if pgp_key:
+        payload["encrypted_secret_access_key"] = _encrypt_pgp(pgp_key, secret_access_key)
+        payload["pgp"] = "yes"
+    else:
+        payload["secret_access_key"] = secret_access_key
+        payload["pgp"] = "no"
+
+    return payload
+
+
+def _encrypt_pgp(public_key_blob, value):
+    if pgpy is None:
+        raise RuntimeError("PGP is configured but the pgpy package is not available; attach a pgpy Lambda layer")
+    public_key, _ = pgpy.PGPKey.from_blob(public_key_blob)
+    message = pgpy.PGPMessage.new(value)
+    return str(public_key.encrypt(message))
+
+
+def _rotation_due(current_secret, rotate_after_days):
+    created_at = _parse_datetime(current_secret.get("created_at"))
+    if created_at is None:
+        return True
+    return (_now() - created_at).days >= rotate_after_days
+
+
+def _cleanup_old_keys(user_name, current_secret, config):
+    if not current_secret:
+        return
+
+    current_key_id = current_secret.get("access_key_id")
+    grace_period_days = int(config.get("grace_period_days", 7))
+    inactive_key_retention_days = int(config.get("inactive_key_retention_days", 30))
+    delete_inactive_keys = _as_bool(config.get("delete_inactive_keys", False))
+
+    for key in _list_access_keys(user_name):
+        key_id = key["AccessKeyId"]
+        if key_id == current_key_id:
+            continue
+        age_days = (_now() - key["CreateDate"]).days
+        if key["Status"] == "Active" and age_days >= grace_period_days:
+            iam.update_access_key(UserName=user_name, AccessKeyId=key_id, Status="Inactive")
+        if delete_inactive_keys and key["Status"] == "Inactive" and age_days >= grace_period_days + inactive_key_retention_days:
+            iam.delete_access_key(UserName=user_name, AccessKeyId=key_id)
+
+
+def _list_access_keys(user_name):
+    keys = []
+    marker = None
+    while True:
+        kwargs = {"UserName": user_name}
+        if marker:
+            kwargs["Marker"] = marker
+        response = iam.list_access_keys(**kwargs)
+        keys.extend(response.get("AccessKeyMetadata", []))
+        if not response.get("IsTruncated"):
+            return sorted(keys, key=lambda item: item["CreateDate"])
+        marker = response.get("Marker")
+
+
+def _parse_datetime(value):
+    if not value:
+        return None
+    parsed = datetime.datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=datetime.timezone.utc)
+    return parsed
+
+
+def _now():
+    return datetime.datetime.now(datetime.timezone.utc)
+
+
+def _as_bool(value):
+    if isinstance(value, bool):
+        return value
+    return str(value).lower() in {"1", "true", "yes", "y"}

--- a/locals.tf
+++ b/locals.tf
@@ -8,11 +8,10 @@
 #
 
 locals {
-  region_arr        = split("-", data.aws_region.current.id)
+  region_arr        = split("-", data.aws_region.current.region) # id & name are deprecated from v6.47.0, use region instead
   region            = format("%s%s%s", lower(local.region_arr[0]), lower(substr(local.region_arr[1], 0, 2)), lower(local.region_arr[2]))
   system_name       = format("%s-%s-%s-%s-%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type), var.spoke_def, local.region)
   system_name_short = format("%s-%s-%s-%s-%s", substr(lower(var.org.organization_unit), 0, 3), substr(lower(var.org.environment_name), 0, 3), substr(lower(replace(var.org.environment_type, "-", "")), 0, 4), var.spoke_def, local.region)
   all_tags          = merge(module.tags.locals.common_tags, var.extra_tags)
   secret_store_path = format("/%s/%s/%s", lower(var.org.organization_unit), lower(var.org.environment_name), lower(var.org.environment_type))
-
 }

--- a/main.tf
+++ b/main.tf
@@ -22,8 +22,9 @@ locals {
         user_name = user.name
         key_name  = key.name
         status    = try(key.status, "Active")
-        pgp_key   = local.default_pgp_key != "" ? local.default_pgp_key : try(user.pgp_key, null)
+        pgp_key   = try(local.user_pgp_key_map[user.name], "") != "" ? local.user_pgp_key_map[user.name] : null
       }
+      if !local.access_key_rotation_enabled || !contains(local.access_key_rotation_user_config_target_names, user.name)
     }
   ]...)
 
@@ -57,7 +58,7 @@ resource "aws_iam_access_key" "this" {
 resource "aws_iam_user_login_profile" "this" {
   for_each                = local.user_console_access
   user                    = aws_iam_user.this[each.key].name
-  pgp_key                 = try(each.value.pgp_key, null)
+  pgp_key                 = try(local.user_pgp_key_map[each.key], "") != "" ? local.user_pgp_key_map[each.key] : null
   password_length         = try(each.value.console_access.password_length, 20)
   password_reset_required = try(each.value.console_access.password_reset_required, true)
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -8,32 +8,108 @@
 #
 
 output "users" {
+  description = "IAM user metadata created by this module. Secret values are not included."
   value = [
     for user in aws_iam_user.this : {
-      name = user.name
-      arn  = user.arn
+      name      = user.name
+      arn       = user.arn
+      path      = user.path
+      unique_id = user.unique_id
     }
   ]
 }
 
+output "users_by_name" {
+  description = "IAM user metadata keyed by IAM user name for downstream module lookups. Secret values are not included."
+  value = {
+    for user in aws_iam_user.this : user.name => {
+      name      = user.name
+      arn       = user.arn
+      path      = user.path
+      unique_id = user.unique_id
+    }
+  }
+}
+
 output "groups" {
+  description = "IAM group metadata for managed and referenced groups. Secret values are not included."
   value = concat([
     for group in aws_iam_group.named : {
-      name = group.name
-      arn  = group.arn
+      name      = group.name
+      arn       = group.arn
+      path      = group.path
+      unique_id = group.unique_id
+      existing  = false
+      kind      = "named"
     }
-    ],
-    [
-      for group in aws_iam_group.prefixed : {
-        name = group.name
-        arn  = group.arn
-      }
+    ], [
+    for group in data.aws_iam_group.named : {
+      name      = group.group_name
+      arn       = group.arn
+      path      = group.path
+      unique_id = try(group.unique_id, group.group_id, group.id)
+      existing  = true
+      kind      = "named"
+    }
+    ], [
+    for group in aws_iam_group.prefixed : {
+      name      = group.name
+      arn       = group.arn
+      path      = group.path
+      unique_id = group.unique_id
+      existing  = false
+      kind      = "prefixed"
+    }
   ])
 }
 
+output "groups_by_name" {
+  description = "IAM group metadata keyed by IAM group name for downstream module lookups. Secret values are not included."
+  value = merge({
+    for group in aws_iam_group.named : group.name => {
+      name      = group.name
+      arn       = group.arn
+      path      = group.path
+      unique_id = group.unique_id
+      existing  = false
+      kind      = "named"
+    }
+    }, {
+    for group in data.aws_iam_group.named : group.group_name => {
+      name      = group.group_name
+      arn       = group.arn
+      path      = group.path
+      unique_id = try(group.unique_id, group.group_id, group.id)
+      existing  = true
+      kind      = "named"
+    }
+    }, {
+    for group in aws_iam_group.prefixed : group.name => {
+      name      = group.name
+      arn       = group.arn
+      path      = group.path
+      unique_id = group.unique_id
+      existing  = false
+      kind      = "prefixed"
+    }
+  })
+}
+
+output "user_group_memberships" {
+  description = "Resolved IAM group memberships keyed by IAM user name."
+  value = {
+    for user_name, membership in aws_iam_user_group_membership.this : user_name => {
+      user   = membership.user
+      groups = membership.groups
+    }
+  }
+}
+
 output "iam_access_keys" {
+  description = "Compatibility output for IAM access key metadata only; secret access key values are not included. Marked sensitive to preserve the historical output contract."
   value = [
-    for key in aws_iam_access_key.this : {
+    for key_name, key in aws_iam_access_key.this : {
+      key_name    = key_name
       id          = key.id
       user_name   = key.user
       create_date = key.create_date
@@ -43,17 +119,178 @@ output "iam_access_keys" {
   sensitive = true
 }
 
+output "iam_access_key_metadata" {
+  description = "Non-secret IAM access key metadata keyed by logical key name. Secret access key values are not included."
+  value = {
+    for key_name, key in aws_iam_access_key.this : key_name => {
+      key_name    = key_name
+      id          = key.id
+      user_name   = key.user
+      create_date = key.create_date
+      status      = key.status
+    }
+  }
+}
+
 output "policies" {
+  description = "IAM managed policy metadata created by this module."
   value = concat([
     for policy in aws_iam_policy.named : {
-      name = policy.name
-      arn  = policy.arn
+      name      = policy.name
+      arn       = policy.arn
+      id        = policy.id
+      policy_id = policy.policy_id
+      path      = policy.path
+      kind      = "named"
     }
-    ],
-    [
-      for policy in aws_iam_policy.prefixed : {
-        name = policy.name
-        arn  = policy.arn
-      }
+    ], [
+    for policy in aws_iam_policy.prefixed : {
+      name      = policy.name
+      arn       = policy.arn
+      id        = policy.id
+      policy_id = policy.policy_id
+      path      = policy.path
+      kind      = "prefixed"
+    }
   ])
+}
+
+output "policies_by_name" {
+  description = "IAM managed policy metadata keyed by policy name for downstream module lookups."
+  value = merge({
+    for policy in aws_iam_policy.named : policy.name => {
+      name      = policy.name
+      arn       = policy.arn
+      id        = policy.id
+      policy_id = policy.policy_id
+      path      = policy.path
+      kind      = "named"
+    }
+    }, {
+    for policy in aws_iam_policy.prefixed : policy.name => {
+      name      = policy.name
+      arn       = policy.arn
+      id        = policy.id
+      policy_id = policy.policy_id
+      path      = policy.path
+      kind      = "prefixed"
+    }
+  })
+}
+
+output "group_policy_attachments" {
+  description = "Resolved IAM group managed-policy attachments, including external policy ARNs and module policy references."
+  value = merge({
+    for key, attachment in aws_iam_group_policy_attachment.named : key => {
+      group      = attachment.group
+      policy_arn = attachment.policy_arn
+      id         = attachment.id
+      kind       = "named_external"
+    }
+    }, {
+    for key, attachment in aws_iam_group_policy_attachment.prefixed : key => {
+      group      = attachment.group
+      policy_arn = attachment.policy_arn
+      id         = attachment.id
+      kind       = "prefixed_external"
+    }
+    }, {
+    for key, attachment in aws_iam_group_policy_attachment.named_refs : key => {
+      group      = attachment.group
+      policy_arn = attachment.policy_arn
+      id         = attachment.id
+      kind       = "named_module_ref"
+    }
+    }, {
+    for key, attachment in aws_iam_group_policy_attachment.prefixed_refs : key => {
+      group      = attachment.group
+      policy_arn = attachment.policy_arn
+      id         = attachment.id
+      kind       = "prefixed_module_ref"
+    }
+  })
+}
+
+output "group_inline_policies" {
+  description = "Resolved IAM group inline policies keyed by module logical attachment name."
+  value = merge({
+    for key, policy in aws_iam_group_policy.named_inline : key => {
+      name  = policy.name
+      group = policy.group
+      id    = policy.id
+      kind  = "named_inline"
+    }
+    }, {
+    for key, policy in aws_iam_group_policy.prefixed_inline : key => {
+      name  = policy.name
+      group = policy.group
+      id    = policy.id
+      kind  = "prefixed_inline"
+    }
+  })
+}
+
+output "secrets_manager_secret_refs" {
+  description = "Secrets Manager secret references created by this module for console credentials and Terraform-managed access keys. Secret values are not included."
+  value = {
+    console_passwords = {
+      for user_name, secret in aws_secretsmanager_secret.user_login : user_name => {
+        name = secret.name
+        arn  = secret.arn
+      }
+    }
+    access_keys = {
+      for key_name, secret in aws_secretsmanager_secret.user_secret : key_name => {
+        name      = secret.name
+        arn       = secret.arn
+        user_name = local.user_access_keys[key_name].user_name
+      }
+    }
+  }
+}
+
+output "access_key_rotation" {
+  description = "Non-secret metadata for the optional AWS Secrets Manager IAM access key rotation control plane. Secret values are not included."
+  value = {
+    enabled                     = local.access_key_rotation_enabled
+    rotation_provider           = "aws_secretsmanager_secret_rotation"
+    create_lambda               = local.access_key_rotation_create_lambda
+    rotate_after_days           = local.access_key_rotation_rotate_after_days
+    automatically_after_days    = local.access_key_rotation_automatically_after_days
+    schedule_expression         = local.access_key_rotation_schedule_expression
+    schedule_duration           = local.access_key_rotation_schedule_duration
+    rotate_immediately          = local.access_key_rotation_rotate_immediately
+    grace_period_days           = local.access_key_rotation_grace_period_days
+    inactive_key_retention_days = local.access_key_rotation_inactive_key_retention_days
+    delete_inactive_keys        = local.access_key_rotation_delete_inactive_keys
+    requested_user_names        = local.access_key_rotation_requested_user_names
+    target_user_names           = local.access_key_rotation_target_user_names
+    configured_user_names       = local.access_key_rotation_user_config_target_names
+    ignored_user_names          = local.access_key_rotation_ignored_user_names
+    user_opt_out_names          = local.access_key_rotation_user_opt_out_names
+    selected_groups             = local.access_key_rotation_group_selectors
+    excluded_users              = local.access_key_rotation_excluded_users
+    pgp_enabled_user_names      = [for user_name, cfg in local.access_key_rotation_user_config : user_name if cfg.pgp_enabled]
+    secret_destination_type     = "secretsmanager"
+    secret_prefix               = local.access_key_rotation_secret_prefix
+    secret_ids                  = local.access_key_rotation_secret_id_map
+    secret_resource_arns        = local.access_key_rotation_secret_resource_arn_map
+    rotation_lambda_arn         = local.access_key_rotation_effective_lambda_arn
+    lambda_function_name        = try(aws_lambda_function.access_key_rotation[0].function_name, null)
+    lambda_function_arn         = try(aws_lambda_function.access_key_rotation[0].arn, null)
+    lambda_role_arn             = try(aws_iam_role.access_key_rotation_lambda[0].arn, null)
+    lambda_log_group_name       = try(aws_cloudwatch_log_group.access_key_rotation_lambda[0].name, null)
+    config_secret_arn           = try(aws_secretsmanager_secret.access_key_rotation_config[0].arn, null)
+    rotation_ids                = { for user_name, rotation in aws_secretsmanager_secret_rotation.access_key_rotation : user_name => rotation.id }
+    runbook_hints = [
+      "Enable access_key_rotation only for module-managed IAM users that should be rotated operationally.",
+      "Rotation is configured with AWS Secrets Manager secret rotation; Secrets Manager invokes the rotation Lambda on the configured schedule.",
+      "Do not consume secret values from Terraform outputs; replacement secrets are written directly to Secrets Manager by the rotation Lambda.",
+      "aws_secretsmanager_secret_rotation is the resource that owns the Secrets Manager rotation schedule and Lambda association for each configured secret.",
+      "For rotating users, Terraform-managed users[*].access_keys are intentionally skipped so aws_iam_access_key is not recreated after the rotation Lambda changes the IAM key set.",
+      "When users is non-empty it overrides group-derived selection; exclude_users and user-level access_key_rotation_enabled=false remove users from either scope.",
+      "If create_secrets is false, provide access_key_rotation.secret_arns for every selected user.",
+      "If any selected user has default_pgp_key or pgp_key configured and create_lambda is true, provide access_key_rotation.lambda_layer_arns with a layer containing pgpy."
+    ]
+  }
 }

--- a/rotation.tf
+++ b/rotation.tf
@@ -1,0 +1,352 @@
+##
+# (c) 2021-2026
+#     Cloud Ops Works LLC - https://cloudops.works/
+#     Find us on:
+#       GitHub: https://github.com/cloudopsworks
+#       WebSite: https://cloudops.works
+#     Distributed Under Apache v2.0 License
+#
+
+locals {
+  access_key_rotation_settings = var.access_key_rotation == null ? {} : var.access_key_rotation
+
+  access_key_rotation_enabled                        = try(local.access_key_rotation_settings.enabled, false)
+  access_key_rotation_user_allowlist                 = try(local.access_key_rotation_settings.users, [])
+  access_key_rotation_group_selectors                = try(local.access_key_rotation_settings.groups, [])
+  access_key_rotation_excluded_users                 = try(local.access_key_rotation_settings.exclude_users, [])
+  access_key_rotation_create_secrets                 = try(local.access_key_rotation_settings.create_secrets, true)
+  access_key_rotation_create_lambda                  = try(local.access_key_rotation_settings.create_lambda, true)
+  access_key_rotation_lambda_arn                     = try(local.access_key_rotation_settings.lambda_arn, null)
+  access_key_rotation_lambda_layer_arns              = try(local.access_key_rotation_settings.lambda_layer_arns, [])
+  access_key_rotation_lambda_timeout                 = try(local.access_key_rotation_settings.lambda_timeout, 60)
+  access_key_rotation_lambda_memory_size             = try(local.access_key_rotation_settings.lambda_memory_size, 256)
+  access_key_rotation_rotate_after_days              = try(local.access_key_rotation_settings.rotate_after_days, 90)
+  access_key_rotation_automatically_after_days       = try(local.access_key_rotation_settings.automatically_after_days, local.access_key_rotation_rotate_after_days)
+  access_key_rotation_schedule_expression            = try(local.access_key_rotation_settings.schedule_expression, null)
+  access_key_rotation_schedule_duration              = try(local.access_key_rotation_settings.schedule_duration, null)
+  access_key_rotation_rotate_immediately             = try(local.access_key_rotation_settings.rotate_immediately, false)
+  access_key_rotation_grace_period_days              = try(local.access_key_rotation_settings.grace_period_days, 7)
+  access_key_rotation_inactive_key_retention_days    = try(local.access_key_rotation_settings.inactive_key_retention_days, 30)
+  access_key_rotation_delete_inactive_keys           = try(local.access_key_rotation_settings.delete_inactive_keys, false)
+  access_key_rotation_secret_prefix                  = trimsuffix(try(local.access_key_rotation_settings.secret_prefix, "") != "" ? local.access_key_rotation_settings.secret_prefix : "${local.secret_store_path}/iam-user/access-key-rotation", "/")
+  access_key_rotation_secret_recovery_window_in_days = try(local.access_key_rotation_settings.secret_recovery_window_in_days, 30)
+  access_key_rotation_secret_kms_key_id              = try(local.access_key_rotation_settings.secret_kms_key_id, null)
+  access_key_rotation_provided_secret_ids            = try(local.access_key_rotation_settings.secret_arns, {})
+  access_key_rotation_function_name                  = substr(try(local.access_key_rotation_settings.lambda_function_name, "") != "" ? local.access_key_rotation_settings.lambda_function_name : "${local.system_name_short}-iam-key-rotation", 0, 64)
+  access_key_rotation_lambda_role_name               = substr(try(local.access_key_rotation_settings.lambda_role_name, "") != "" ? local.access_key_rotation_settings.lambda_role_name : "${local.system_name_short}-iam-key-rotation-lambda", 0, 64)
+  access_key_rotation_config_secret_name             = try(local.access_key_rotation_settings.config_secret_name, "") != "" ? local.access_key_rotation_settings.config_secret_name : "${local.access_key_rotation_secret_prefix}/_rotation-config"
+  access_key_rotation_log_retention_days             = try(local.access_key_rotation_settings.log_retention_days, 30)
+
+  user_pgp_secret_ids = {
+    for user in var.users : user.name => replace(user.pgp_key, "_aws:", "")
+    if try(user.pgp_key, "") != "" && startswith(try(user.pgp_key, ""), "_aws:")
+  }
+  user_pgp_key_map = {
+    for user in var.users : user.name => try(user.pgp_key, "") != "" ? (
+      startswith(try(user.pgp_key, ""), "_aws:") ? try(data.aws_secretsmanager_secret_version.user_pgp_public_key[user.name].secret_string, "") : user.pgp_key
+    ) : local.default_pgp_key
+  }
+
+  access_key_rotation_all_user_names = [for user in var.users : user.name]
+  access_key_rotation_group_user_names = distinct(flatten([
+    for user in var.users : [
+      for group in try(user.groups, []) : user.name
+      if contains(local.access_key_rotation_group_selectors, group)
+    ]
+  ]))
+  access_key_rotation_user_opt_out_names = sort([
+    for user in var.users : user.name
+    if try(user.access_key_rotation_enabled, true) == false ||
+    try(tobool(user.access_key_rotation), true) == false ||
+    try(user.access_key_rotation.enabled, true) == false ||
+    try(user.access_key_rotation.opt_out, false) == true
+  ])
+  access_key_rotation_requested_user_names = sort(tolist(setsubtract(
+    toset(length(local.access_key_rotation_user_allowlist) > 0 ? local.access_key_rotation_user_allowlist : (
+      length(local.access_key_rotation_group_selectors) > 0 ? local.access_key_rotation_group_user_names : local.access_key_rotation_all_user_names
+    )),
+    setunion(toset(local.access_key_rotation_excluded_users), toset(local.access_key_rotation_user_opt_out_names))
+  )))
+  access_key_rotation_target_user_names = [
+    for user_name in local.access_key_rotation_requested_user_names : user_name
+    if contains(keys(local.users_map), user_name)
+  ]
+  access_key_rotation_ignored_user_names = sort(tolist(setsubtract(
+    toset(local.access_key_rotation_requested_user_names),
+    toset(local.access_key_rotation_target_user_names)
+  )))
+  access_key_rotation_targets = {
+    for user_name in local.access_key_rotation_target_user_names : user_name => local.users_map[user_name]
+  }
+  access_key_rotation_target_user_arns = [
+    for user_name in local.access_key_rotation_target_user_names : aws_iam_user.this[user_name].arn
+  ]
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_partition" "current" {}
+
+data "aws_secretsmanager_secret_version" "user_pgp_public_key" {
+  for_each  = local.user_pgp_secret_ids
+  secret_id = each.value
+}
+
+resource "aws_secretsmanager_secret" "access_key_rotation" {
+  for_each = local.access_key_rotation_enabled && local.access_key_rotation_create_secrets ? local.access_key_rotation_targets : {}
+
+  name                    = "${local.access_key_rotation_secret_prefix}/${each.key}"
+  kms_key_id              = local.access_key_rotation_secret_kms_key_id
+  recovery_window_in_days = local.access_key_rotation_secret_recovery_window_in_days
+  tags                    = local.all_tags
+}
+
+locals {
+  access_key_rotation_created_secret_ids = {
+    for user_name, secret in aws_secretsmanager_secret.access_key_rotation : user_name => secret.arn
+  }
+  access_key_rotation_created_secret_names = {
+    for user_name, secret in aws_secretsmanager_secret.access_key_rotation : user_name => secret.name
+  }
+  access_key_rotation_secret_id_map = merge(
+    local.access_key_rotation_provided_secret_ids,
+    local.access_key_rotation_created_secret_ids
+  )
+  access_key_rotation_secret_name_map = merge(
+    {
+      for user_name, secret_id in local.access_key_rotation_provided_secret_ids : user_name => startswith(secret_id, "arn:") ? null : secret_id
+    },
+    local.access_key_rotation_created_secret_names
+  )
+  access_key_rotation_secret_resource_arn_map = {
+    for user_name, secret_id in local.access_key_rotation_secret_id_map : user_name => startswith(secret_id, "arn:") ? secret_id : "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:${secret_id}-*"
+  }
+  access_key_rotation_secret_resource_arns = values(local.access_key_rotation_secret_resource_arn_map)
+  access_key_rotation_user_config_target_names = [
+    for user_name in local.access_key_rotation_target_user_names : user_name
+    if contains(keys(local.access_key_rotation_secret_id_map), user_name)
+  ]
+  access_key_rotation_user_config = {
+    for user_name in local.access_key_rotation_user_config_target_names : user_name => {
+      secret_id   = local.access_key_rotation_secret_id_map[user_name]
+      secret_arn  = try(local.access_key_rotation_secret_resource_arn_map[user_name], null)
+      secret_name = try(local.access_key_rotation_secret_name_map[user_name], null)
+      pgp_key     = try(local.user_pgp_key_map[user_name], "")
+      pgp_enabled = try(local.user_pgp_key_map[user_name], "") != ""
+    }
+  }
+  access_key_rotation_pgp_enabled          = anytrue([for _, cfg in local.access_key_rotation_user_config : cfg.pgp_enabled])
+  access_key_rotation_effective_lambda_arn = local.access_key_rotation_create_lambda ? try(aws_lambda_function.access_key_rotation[0].arn, null) : local.access_key_rotation_lambda_arn
+}
+
+resource "aws_secretsmanager_secret" "access_key_rotation_config" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  name                    = local.access_key_rotation_config_secret_name
+  kms_key_id              = local.access_key_rotation_secret_kms_key_id
+  recovery_window_in_days = local.access_key_rotation_secret_recovery_window_in_days
+  tags                    = local.all_tags
+
+  lifecycle {
+    precondition {
+      condition     = length(local.access_key_rotation_user_config) > 0
+      error_message = "access_key_rotation.enabled requires at least one selected module-managed user with a Secrets Manager destination. Leave create_secrets=true or provide access_key_rotation.secret_arns."
+    }
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "access_key_rotation_config" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  secret_id = aws_secretsmanager_secret.access_key_rotation_config[0].id
+  secret_string = jsonencode({
+    users                       = local.access_key_rotation_user_config
+    rotate_after_days           = local.access_key_rotation_rotate_after_days
+    grace_period_days           = local.access_key_rotation_grace_period_days
+    inactive_key_retention_days = local.access_key_rotation_inactive_key_retention_days
+    delete_inactive_keys        = local.access_key_rotation_delete_inactive_keys
+  })
+}
+
+data "archive_file" "access_key_rotation_lambda" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  type        = "zip"
+  source_file = "${path.module}/lambda/iam_access_key_rotation.py"
+  output_path = "${path.root}/.terraform/iam_access_key_rotation_${filesha256("${path.module}/lambda/iam_access_key_rotation.py")}.zip"
+}
+
+data "aws_iam_policy_document" "access_key_rotation_lambda_assume_role" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "access_key_rotation_lambda" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  name               = local.access_key_rotation_lambda_role_name
+  assume_role_policy = data.aws_iam_policy_document.access_key_rotation_lambda_assume_role[0].json
+  tags               = local.all_tags
+}
+
+data "aws_iam_policy_document" "access_key_rotation_lambda" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  statement {
+    sid    = "WriteLogs"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = ["${aws_cloudwatch_log_group.access_key_rotation_lambda[0].arn}:*"]
+  }
+
+  statement {
+    sid    = "ReadRotationConfig"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue"
+    ]
+    resources = [aws_secretsmanager_secret.access_key_rotation_config[0].arn]
+  }
+
+  statement {
+    sid    = "ManageRotatedSecrets"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:PutSecretValue",
+      "secretsmanager:UpdateSecretVersionStage"
+    ]
+    resources = length(local.access_key_rotation_secret_resource_arns) > 0 ? local.access_key_rotation_secret_resource_arns : [
+      "arn:${data.aws_partition.current.partition}:secretsmanager:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:secret:__no_rotation_targets__-*"
+    ]
+  }
+
+  statement {
+    sid    = "RotateSelectedUserAccessKeys"
+    effect = "Allow"
+    actions = [
+      "iam:CreateAccessKey",
+      "iam:DeleteAccessKey",
+      "iam:GetUser",
+      "iam:ListAccessKeys",
+      "iam:UpdateAccessKey"
+    ]
+    resources = length(local.access_key_rotation_target_user_arns) > 0 ? local.access_key_rotation_target_user_arns : [
+      "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:user/__no_rotation_targets__"
+    ]
+  }
+
+  dynamic "statement" {
+    for_each = local.access_key_rotation_secret_kms_key_id == null ? [] : [1]
+
+    content {
+      sid    = "UseRotationSecretKmsKey"
+      effect = "Allow"
+      actions = [
+        "kms:Decrypt",
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = [local.access_key_rotation_secret_kms_key_id]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "access_key_rotation_lambda" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  name   = "${local.access_key_rotation_lambda_role_name}-policy"
+  role   = aws_iam_role.access_key_rotation_lambda[0].id
+  policy = data.aws_iam_policy_document.access_key_rotation_lambda[0].json
+}
+
+resource "aws_cloudwatch_log_group" "access_key_rotation_lambda" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  name              = "/aws/lambda/${local.access_key_rotation_function_name}"
+  retention_in_days = local.access_key_rotation_log_retention_days
+  tags              = local.all_tags
+}
+
+resource "aws_lambda_function" "access_key_rotation" {
+  count = local.access_key_rotation_enabled && local.access_key_rotation_create_lambda ? 1 : 0
+
+  function_name    = local.access_key_rotation_function_name
+  description      = "Rotates IAM user access keys through AWS Secrets Manager rotation."
+  filename         = data.archive_file.access_key_rotation_lambda[0].output_path
+  source_code_hash = data.archive_file.access_key_rotation_lambda[0].output_base64sha256
+  role             = aws_iam_role.access_key_rotation_lambda[0].arn
+  handler          = "iam_access_key_rotation.handler"
+  runtime          = "python3.11"
+  timeout          = local.access_key_rotation_lambda_timeout
+  memory_size      = local.access_key_rotation_lambda_memory_size
+  layers           = local.access_key_rotation_lambda_layer_arns
+  tags             = local.all_tags
+
+  environment {
+    variables = {
+      ROTATION_CONFIG_SECRET_ID = aws_secretsmanager_secret.access_key_rotation_config[0].arn
+    }
+  }
+
+  depends_on = [
+    aws_cloudwatch_log_group.access_key_rotation_lambda,
+    aws_iam_role_policy.access_key_rotation_lambda
+  ]
+
+  lifecycle {
+    precondition {
+      condition     = !local.access_key_rotation_pgp_enabled || length(local.access_key_rotation_lambda_layer_arns) > 0
+      error_message = "PGP is configured for at least one rotated user. Provide access_key_rotation.lambda_layer_arns with a layer containing the pgpy package."
+    }
+  }
+}
+
+resource "aws_lambda_permission" "access_key_rotation" {
+  for_each = local.access_key_rotation_enabled ? local.access_key_rotation_user_config : {}
+
+  statement_id   = "AllowSecretsManager${substr(sha1(each.key), 0, 16)}"
+  action         = "lambda:InvokeFunction"
+  function_name  = local.access_key_rotation_effective_lambda_arn
+  principal      = "secretsmanager.amazonaws.com"
+  source_account = data.aws_caller_identity.current.account_id
+  source_arn     = local.access_key_rotation_secret_resource_arn_map[each.key]
+}
+
+resource "aws_secretsmanager_secret_rotation" "access_key_rotation" {
+  for_each = local.access_key_rotation_enabled ? local.access_key_rotation_user_config : {}
+
+  secret_id           = local.access_key_rotation_secret_id_map[each.key]
+  rotation_lambda_arn = local.access_key_rotation_effective_lambda_arn
+  rotate_immediately  = local.access_key_rotation_rotate_immediately
+
+  rotation_rules {
+    automatically_after_days = local.access_key_rotation_schedule_expression == null ? local.access_key_rotation_automatically_after_days : null
+    schedule_expression      = local.access_key_rotation_schedule_expression
+    duration                 = local.access_key_rotation_schedule_duration
+  }
+
+  depends_on = [aws_lambda_permission.access_key_rotation]
+
+  lifecycle {
+    precondition {
+      condition     = local.access_key_rotation_create_lambda || local.access_key_rotation_lambda_arn != null
+      error_message = "When access_key_rotation.create_lambda is false, access_key_rotation.lambda_arn is required."
+    }
+  }
+}

--- a/variables-iam.tf
+++ b/variables-iam.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -27,13 +27,49 @@ variable "default_pgp_key" {
   default     = ""
 }
 
+
+# access_key_rotation: # (Optional) Opt-in AWS Secrets Manager rotation control plane for IAM access keys. Default: disabled.
+#   enabled: false # (Optional) When true, configure Secrets Manager rotation for selected module-managed users. Default: false
+#   create_lambda: true # (Optional) When true, create the IAM access key rotation Lambda. Set false to use lambda_arn. Default: true
+#   lambda_arn: null # (Optional) Existing rotation Lambda ARN to use when create_lambda is false. Default: null
+#   lambda_layer_arns: [] # (Optional) Lambda layer ARNs. Required when PGP is active with the module-created Lambda; include a layer that provides pgpy. Default: []
+#   lambda_timeout: 60 # (Optional) Module-created Lambda timeout in seconds. Default: 60
+#   lambda_memory_size: 256 # (Optional) Module-created Lambda memory size in MB. Default: 256
+#   lambda_function_name: "org-env-type-001-use1-iam-key-rotation" # (Optional) Module-created Lambda function name, truncated to 64 characters. Default: "<system_name_short>-iam-key-rotation"
+#   lambda_role_name: "org-env-type-001-use1-iam-key-rotation-lambda" # (Optional) Module-created Lambda IAM role name, truncated to 64 characters. Default: "<system_name_short>-iam-key-rotation-lambda"
+#   log_retention_days: 30 # (Optional) CloudWatch log retention for the module-created Lambda. Default: 30
+#   automatically_after_days: 90 # (Optional) Secrets Manager automatic rotation interval when schedule_expression is not set. Default: rotate_after_days
+#   schedule_expression: null # (Optional) Secrets Manager rotation schedule expression, for example "rate(30 days)" or a cron expression. Mutually exclusive with automatically_after_days. Default: null
+#   schedule_duration: null # (Optional) Rotation window duration such as "2h" when schedule_expression is set. Default: null
+#   rotate_immediately: false # (Optional) Whether to rotate immediately when rotation configuration is created. Default: false
+#   rotate_after_days: 90 # (Optional) Lambda-side minimum age before it creates a replacement key. Default: 90
+#   grace_period_days: 7 # (Optional) Days before older non-current keys are deactivated during a rotation invocation. Default: 7
+#   inactive_key_retention_days: 30 # (Optional) Additional days before deleting inactive keys when delete_inactive_keys is true. Default: 30
+#   delete_inactive_keys: false # (Optional) Delete inactive keys after grace_period_days + inactive_key_retention_days. Default: false
+#   users: [] # (Optional) Explicit module-managed user allowlist. When provided, it overrides group-derived selection. Default: []
+#   groups: [] # (Optional) Group references used in users[*].groups to derive selected users when users is empty. Default: []
+#   exclude_users: [] # (Optional) Module-managed users removed from either all-users or group-derived scope. Default: []
+#   create_secrets: true # (Optional) When true, create one Secrets Manager secret per selected user and enable rotation on it. Default: true
+#   secret_prefix: "/org/env/type/iam-user/access-key-rotation" # (Optional) Prefix for module-created Secrets Manager secrets. Default: "/<org_unit>/<environment_name>/<environment_type>/iam-user/access-key-rotation"
+#   secret_arns: {} # (Optional) Map of user name to existing Secrets Manager secret ARN/name when create_secrets is false or custom destinations are needed. Default: {}
+#   secret_kms_key_id: null # (Optional) KMS key ID/ARN for module-created Secrets Manager secrets and rotation config. Default: null
+#   secret_recovery_window_in_days: 30 # (Optional) Recovery window for module-created Secrets Manager secrets. Default: 30
+#   config_secret_name: "/org/env/type/iam-user/access-key-rotation/_rotation-config" # (Optional) Name for the module-created Lambda configuration secret. Default: "<secret_prefix>/_rotation-config"
+#
+variable "access_key_rotation" {
+  description = "Optional AWS Secrets Manager IAM access key rotation control plane. Disabled by default. See comments above for full schema."
+  type        = any
+  default     = {}
+}
+
 # ----------------------------------------------------------------------------
 # users
 # ----------------------------------------------------------------------------
 # users:
 #   - name: "username" # (Required) IAM user name
 #     path: "/" # (Optional) IAM path (e.g., "/service/"). Default: "/"
-#     pgp_key: "armored_pgp_key" # (Optional) Default PGP key for encrypting secrets. Accepts raw armored PGP or "_aws:<secret_id>" to load it from AWS Secrets Manager. Default: ""
+#     pgp_key: "armored_pgp_key" # (Optional) User-specific PGP key for encrypting secrets. Accepts raw armored PGP or "_aws:<secret_id>" to load it from AWS Secrets Manager. Default: ""
+#     access_key_rotation_enabled: true # (Optional) User-level opt-in/opt-out flag for the module-level access_key_rotation selection. Set false to exclude this user even when selected by users/groups/all-users scope. Default: true
 #     groups: ["group1"] # (Optional) Group memberships for this user. For named groups, use the exact group.name. For prefixed groups, use the group.name_prefix. Default: []
 #     access_keys: # (Optional) Access keys to create for this user. Default: []
 #       - name: "key1" # (Required) Logical name for the key (used internally)

--- a/variables.tf
+++ b/variables.tf
@@ -1,5 +1,5 @@
 ##
-# (c) 2021-2025
+# (c) 2021-2026
 #     Cloud Ops Works LLC - https://cloudops.works/
 #     Find us on:
 #       GitHub: https://github.com/cloudopsworks
@@ -7,18 +7,31 @@
 #     Distributed Under Apache v2.0 License
 #
 
-# Establish this is a HUB or spoke configuration
+# is_hub: false # (Optional) Is this a hub or spoke configuration? Default: false
 variable "is_hub" {
-  type    = bool
-  default = false
+  description = "Is this a hub or spoke configuration?"
+  type        = bool
+  default     = false
 }
 
+# spoke_def: "001" # (Optional) Spoke ID Number, must be a 3 digit number. Default: "001"
 variable "spoke_def" {
-  type    = string
-  default = "001"
+  description = "Spoke ID Number, must be a 3 digit number"
+  type        = string
+  default     = "001"
+  validation {
+    condition     = (length(var.spoke_def) == 3) && tonumber(var.spoke_def) != null
+    error_message = "The spoke_def must be a 3 digit number as string."
+  }
 }
 
+# org: # (Required) Organization details
+#   organization_name: "example" # (Required) The name of the organization
+#   organization_unit: "devops"  # (Required) The unit within the organization
+#   environment_type: "production" # (Required) The type of environment (e.g. production, staging)
+#   environment_name: "prod"      # (Required) The name of the environment
 variable "org" {
+  description = "Organization details"
   type = object({
     organization_name = string
     organization_unit = string
@@ -27,7 +40,10 @@ variable "org" {
   })
 }
 
+# extra_tags: # (Optional) Extra tags to add to the resources. Default: {}
+#   Tag1: "Value1"
 variable "extra_tags" {
-  type    = map(string)
-  default = {}
+  description = "Extra tags to add to the resources"
+  type        = map(string)
+  default     = {}
 }

--- a/versions.tf
+++ b/versions.tf
@@ -13,7 +13,11 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 6.4"
+      version = "~> 6.35"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = "~> 2.7"
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add AWS Secrets Manager rotation resources and Lambda-backed IAM access key rotation.
- Support PGP-aware rotation using resolved user/default PGP keys and optional pgpy Lambda layer.
- Add user-level rotation opt-out while preserving Terraform-managed access keys for opted-out users.
- Skip Terraform-managed aws_iam_access_key resources for users managed by rotation to avoid recreation drift.
- Expand non-secret outputs and Terragrunt/README documentation for rotation operations.

+semver: minor